### PR TITLE
v0.3: section raid leaders, more roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Zero
-This repository is a newer repository; the older one is currently not public due to some sensitive credentials being leaked (we have since changed the passwords). If you would like to view the original repository, please submit an issue. Thanks.
+**NOTE: This repository is a newer repository; the older one is currently not public due to some sensitive credentials being leaked (we have since changed the passwords). If you would like to view the original repository, please submit an issue. Thanks.**
 
 A [Realm of the Mad God](https://www.realmofthemadgod.com/) Discord Bot designed for verification, moderation, and raid management.
 
@@ -18,6 +18,16 @@ The main purpose of this bot is for the Dungeoneer Exalt Discord server, where I
 I am working very closely with both the server's other co-owner and staff members. REMEMBER that this bot was created in mind for a particular server -- the Dungeoneer Exalt server. This server is also being created under the assumption that there will be a network; that is, a group of servers under one or more owner(s) working together towards a common goal.
 
 THEREFORE, there will be no official public version of this bot.
+
+## Use of Source Code
+Since this is an open-source project, I don't generally mind, or care, about how you use this bot. However, I would *greatly* appreciate it if you used this bot in a private manner. 
+
+I encourage you to use the bot's source code for the following:
+- For the use of guild verification/runs.
+- Server of friends.
+
+I do not encourage (in fact, I will frown upon) the use of the bot's source code for the following:
+- To start a public server (think Fungal, Pub Halls, Dungeoneer).
 
 ## Project Layout
 For this repository, the `master` branch is the developer's branch. In other words, the branch where unstable code -- code that either won't compile, has numerous errors, is incomplete, etc. -- will be pushed. 
@@ -42,16 +52,40 @@ The `stable` branch is where code that generally has no errors will reside. The 
 **Getting the Bot Files**
 1. Download or clone this repository. To make it easier, click `Clone or download` to open a dropdown menu. Then, click `Donwload ZIP`. Extract the downloaded files.
 2. In the root directory (where the `src` folder and `package.json` file exists) of the bot files, open your terminal or command prompt and run `npm i`. This will install all required dependencies.
-3. Look for the folder containing the code. Go to the bot's configuration folder ("./src/Configuration") and look for the `Config.Example.ts` file. Fill out all applicable information there.
+3. Look for the folder containing the code. Go to the bot's configuration folder ("./src/Configuration") and look for the `Config.Example.ts` file. Fill out all applicable information there. Rename the file to `Config.ts`. 
 4. Now, head over to `./src/Constants/AFKDungeon.ts`. This file contains all of the dungeons that the bot currently supports. For each element (dungeon data), change the value of `portalEmojiID` to the ID of the emoji of the dungeon's portal (you will need to add your own emojis on your own server). You also want to go to `keyEmojIDs`, and for each element in this array, change the value of `keyEmojID` to the ID of the dungeon key. FAILURE TO DO THIS WILL RESULT IN ERRORS! 
 5. In your terminal or command prompt, run `npm run start`. This will compile and, hopefully, run the file.
 
 ## Support
-Unfortunately, I will be providing very __limited__ support when it comes to setting up the bot. However, if there are issues with the code itself (notably, errors), or have questions in general, please feel free to open a new issue.
+I will be more than happy to help you setup the bot. However, this does come at a cost -- I would like to know how you plan on using this bot. 
 
 Please remember that this bot was created in mind for a particular server; however, this bot is cross-compatible, meaning it will work across any server(s) it is in. I will provide very limited support, if any at all, if your question in mind has to do with altering/removing a particular feature that was designed for the server.
 
 Eventually, if the demand arises, I'll make a support server for this bot. 
 
 ## Other Stuff
-This [repository](https://github.com/ewang20027/ZeroRaidBot) represents the OFFICIAL repository of Zero. All code written and published in this repository were written by me unless otherwise said. 
+This [repository](https://github.com/DungeoneerExalt/ZeroRaidBot) represents the OFFICIAL repository of Zero. All code written and published in this repository were written by members of the [organization](https://github.com/DungeoneerExalt) unless otherwise said. 
+
+## Support the Project
+The best way to support this project is to star it! And if you'd like, submit an issue describing what you will be using the bot for. I am very interested in seeing how the community uses this bot.
+
+## License
+Copyright (c) 2020 Edward Wang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "raidbot",
-	"version": "0.1.2",
+	"version": "0.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -48,9 +48,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "12.12.38",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.38.tgz",
-			"integrity": "sha512-75eLjX0pFuTcUXnnWmALMzzkYorjND0ezNEycaKesbUBg9eGZp4GHPuDmkRc4mQQvIpe29zrzATNRA6hkYqwmA==",
+			"version": "12.12.39",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.39.tgz",
+			"integrity": "sha512-pADGfwnDkr6zagDwEiCVE4yQrv7XDkoeVa4OfA9Ju/zRTk6YNDLGtQbkdL4/56mCQQCs4AhNrBIag6jrp7ZuOg==",
 			"dev": true
 		},
 		"@types/ws": {
@@ -307,9 +307,9 @@
 			"integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
 		},
 		"typescript": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
+			"integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
 			"dev": true
 		},
 		"util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
 	"devDependencies": {
 		"@types/axios": "^0.14.0",
 		"@types/mongodb": "^3.5.16",
-		"@types/node": "^12.12.38",
+		"@types/node": "^12.12.39",
 		"@types/ws": "^6.0.4",
-		"typescript": "^3.8.3"
+		"typescript": "^3.9.2"
 	},
 	"scripts": {
 		"compile": "tsc -p .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "raidbot",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "Zero is a Discord bot written in TypeScript, designed for raid management, moderation, and fun.",
 	"main": "index.js",
 	"dependencies": {

--- a/src/Commands/Configuration/ConfigureSectionCommand.ts
+++ b/src/Commands/Configuration/ConfigureSectionCommand.ts
@@ -197,6 +197,13 @@ export class ConfigureSectionCommand extends Command {
 			sectMongo: ""
 		},
 		{
+			q: "Configure Officer Role",
+			d: "Mention, or type the ID of, the role that you want to make the Officer role. Officers will be able to access most moderation commands, including blacklists. Think of officers like Head Leaders, but without the ability to lead.",
+			m: true,
+			mainMongo: "roles.officer",
+			sectMongo: ""
+		},
+		{
 			q: "Configure Universal Leader Role",
 			d: "Mention, or type the ID of, the role that you want to make the Universal Leader role. Leaders will have the ability to suspend members. **NOTE:** Universal Leaders have the ability to start AFK checks and headcounts in ANY section.",
 			m: true,
@@ -239,6 +246,13 @@ export class ConfigureSectionCommand extends Command {
 			sectMongo: ""
 		},
 		{
+			q: "Configure Verifier Role",
+			d: "Mention, or type the ID of, the role that you want to make the Verifier role. Verifiers will be able to access the find and manual verification command.",
+			m: true,
+			mainMongo: "roles.verifier",
+			sectMongo: ""
+		},
+		{
 			q: "Configure Pardoned Leader Role",
 			d: "Mention, or type the ID of, the role that you want to make the Pardoned Leader role. Pardoned Leaders are simply leaders, regardless of original rank, on leave. That is, they are taking a break from leading.",
 			m: true,
@@ -271,7 +285,7 @@ export class ConfigureSectionCommand extends Command {
 			new CommandPermission(
 				["ADMINISTRATOR"],
 				["ADD_REACTIONS", "MANAGE_MESSAGES", "EMBED_LINKS"],
-				[],
+				["moderator"],
 				[],
 				false
 			),
@@ -1006,9 +1020,11 @@ export class ConfigureSectionCommand extends Command {
 				.addField("Configure Team Role", "React with 👪 to configure the Team role.")
 				.addField("Configure Moderator Role", "React with ⚒️ to configure the Moderator role.")
 				.addField("Configure Head Leader Role", "React with 🥇 to configure the Head Leader role.")
+				.addField("Configure Officer Role", "React with 👮 to configure the Officer role.")
 				.addField("Configure Universal Leader Role", "React with 🥈 to configure the Universal Leader role.")
 				.addField("Configure Universal Almost Leader Role", "React with 🥉 to configure the Universal Almost Leader role.")
 				.addField("Configure Support Role", "React with 📛 to configure the Support/Helper role.")
+				.addField("Configure Verifier Role", "React with 🔎 to configure the Verifier role.")
 				.addField("Configure Pardoned Leader Role", "React with 💤 to configure the Pardoned Leader role.")
 				.addField("Configure Suspended Role", "React with ⛔ to configure the Suspended role.")
 				.addField("Configure Talking Roles", "React with 🔈 to configure talking roles.")
@@ -1017,7 +1033,7 @@ export class ConfigureSectionCommand extends Command {
 			//.addField("Configure Tier II Key Role", "React with 🔑 to configure the Tier 2 Key Donator role.")
 			//.addField("Configure Tier III Key Role", "React with 🍀 to configure the Tier 3 Key Donator role.");
 
-			reactions.push("👪", "⚒️", "🥇", "🥈", "🥉", "📛", "💤", "⛔", "🔈", "🗺️");
+			reactions.push("👪", "⚒️", "🥇", "👮", "🥈", "🥉", "📛", "🔎", "💤", "⛔", "🔈", "🗺️");
 			// , "🔈", "🗝️", "🔑", "🍀"
 		}
 
@@ -1217,6 +1233,28 @@ export class ConfigureSectionCommand extends Command {
 					section.isMain
 						? "roles.mainSectionLeaderRole.sectionTrialLeaderRole"
 						: "sections.$.roles.trialLeaderRole"
+				);
+			}
+			// officer
+			else if (r.emoji.name === "👮") {
+				await this.resetBotEmbed(botSentMsg).catch(() => { });
+				res = await this.updateRoleCommand(
+					msg,
+					"Officer Role",
+					section,
+					guild.roles.cache.get(guildData.roles.officer),
+					"roles.officer"
+				);
+			}
+			// verifier
+			else if (r.emoji.name === "🔎") {
+				await this.resetBotEmbed(botSentMsg).catch(() => { });
+				res = await this.updateRoleCommand(
+					msg,
+					"Verifier Role",
+					section,
+					guild.roles.cache.get(guildData.roles.verifier),
+					"roles.verifier"
 				);
 			}
 			// configuration wizard
@@ -2121,9 +2159,11 @@ Verification Channel: ${typeof verificationChannel !== "undefined" ? verificatio
 		const teamRole: Role | undefined = guild.roles.cache.get(guildData.roles.teamRole);
 		const moderatorRole: Role | undefined = guild.roles.cache.get(guildData.roles.moderator);
 		const headLeaderRole: Role | undefined = guild.roles.cache.get(guildData.roles.headRaidLeader);
+		const officerRole: Role | undefined = guild.roles.cache.get(guildData.roles.officer);
 		const leaderRole: Role | undefined = guild.roles.cache.get(guildData.roles.universalRaidLeader);
 		const almostLeaderRole: Role | undefined = guild.roles.cache.get(guildData.roles.universalAlmostRaidLeader);
 		const supportRole: Role | undefined = guild.roles.cache.get(guildData.roles.support);
+		const verifierRole: Role | undefined = guild.roles.cache.get(guildData.roles.verifier);
 		const pardonedLeaderRole: Role | undefined = guild.roles.cache.get(guildData.roles.pardonedRaidLeader);
 		const suspendedRole: Role | undefined = guild.roles.cache.get(guildData.roles.suspended);
 		const allTalkingRoles: (Role | undefined)[] = guildData.roles.talkingRoles.map(x => guild.roles.cache.get(x));
@@ -2230,11 +2270,15 @@ Verification Channel: ${typeof verificationChannel !== "undefined" ? verificatio
 				.appendLine()
 				.append(`Head Leader Role: ${typeof headLeaderRole === "undefined" ? "N/A" : headLeaderRole}`)
 				.appendLine()
-				.append(`Leader Role: ${typeof leaderRole === "undefined" ? "N/A" : leaderRole}`)
+				.append(`Officer Role: ${typeof officerRole === "undefined" ? "N/A" : officerRole}`)
 				.appendLine()
-				.append(`Almost Leader Role: ${typeof almostLeaderRole === "undefined" ? "N/A" : almostLeaderRole}`)
+				.append(`Universal Leader Role: ${typeof leaderRole === "undefined" ? "N/A" : leaderRole}`)
+				.appendLine()
+				.append(`Universal Almost Leader Role: ${typeof almostLeaderRole === "undefined" ? "N/A" : almostLeaderRole}`)
 				.appendLine()
 				.append(`Support Role: ${typeof supportRole === "undefined" ? "N/A" : supportRole}`)
+				.appendLine()
+				.append(`Verifier Role: ${typeof verifierRole === "undefined" ? "N/A" : verifierRole}`)
 				.appendLine()
 				.append(`Pardoned Leader Role: ${typeof pardonedLeaderRole === "undefined" ? "N/A" : pardonedLeaderRole}`)
 				.appendLine()

--- a/src/Commands/Configuration/ConfigureSectionCommand.ts
+++ b/src/Commands/Configuration/ConfigureSectionCommand.ts
@@ -207,7 +207,7 @@ export class ConfigureSectionCommand extends Command {
 			q: "Configure Section Leader Role",
 			d: "Mention, or type the ID of, the role that you want to make the Section Leader role. Section Leaders will have the ability to suspend members. **NOTE:** Unlike universal leaders, section leaders can only start AFK checks and headcounts in their designated sections.",
 			m: false,
-			mainMongo: "roles.sectionLeaderRole",
+			mainMongo: "roles.mainSectionLeaderRole.sectionLeaderRole",
 			sectMongo: "sections.$.roles.raidLeaderRole"
 		},
 		{
@@ -222,13 +222,13 @@ export class ConfigureSectionCommand extends Command {
 			d: "Mention, or type the ID of, the role that you want to make the Section Almost Leader role. Section Almost Leaders are leaders that have more experience than a Section Trial Leader but are not quite ready for the full responsibilities associated with being a full-on Section Leader. **NOTE:** Unlike universal almost leaders, section almost leaders can only start AFK checks and headcounts in their designated sections.", // this sounds awkward to say out loud, doesn't it? 
 			m: false,
 			mainMongo: "roles.sectionAlmostLeader",
-			sectMongo: "sections.$.roles.sectionAlmostLeaderRole"
+			sectMongo: "sections.$.roles.mainSectionLeaderRole.sectionAlmostLeaderRole"
 		},
 		{
 			q: "Configure Section Trial Leader Role",
 			d: "Mention, or type the ID of, the role that you want to make the Section Leader role. Section Trial Leaders will be able to start AFK checks in their designated sections with approval from a Raid Leader. **NOTE:** Sction trial leaders can only start AFK checks and headcounts in their designated sections.",
 			m: false,
-			mainMongo: "roles.sectionTrialLeaderRole",
+			mainMongo: "roles.mainSectionLeaderRole.sectionTrialLeaderRole",
 			sectMongo: "section.$.roles.trialLeaderRole"
 		},
 		{
@@ -1190,7 +1190,7 @@ export class ConfigureSectionCommand extends Command {
 					section,
 					guild.roles.cache.get(section.roles.raidLeaderRole),
 					section.isMain
-						? "roles.sectionLeaderRole"
+						? "roles.mainSectionLeaderRole.sectionLeaderRole"
 						: "sections.$.roles.raidLeaderRole"
 				);
 			}
@@ -1203,7 +1203,7 @@ export class ConfigureSectionCommand extends Command {
 					section,
 					guild.roles.cache.get(section.roles.almostLeaderRole),
 					section.isMain
-						? "roles.sectionAlmostLeaderRole"
+						? "roles.mainSectionLeaderRole.sectionAlmostLeaderRole"
 						: "sections.$.roles.almostLeaderRole"
 				);
 			}
@@ -1216,7 +1216,7 @@ export class ConfigureSectionCommand extends Command {
 					section,
 					guild.roles.cache.get(section.roles.trialLeaderRole),
 					section.isMain
-						? "roles.sectionTrialLeaderRole"
+						? "roles.mainSectionLeaderRole.sectionTrialLeaderRole"
 						: "sections.$.roles.trialLeaderRole"
 				);
 			}

--- a/src/Commands/Configuration/ConfigureSectionCommand.ts
+++ b/src/Commands/Configuration/ConfigureSectionCommand.ts
@@ -173,7 +173,7 @@ export class ConfigureSectionCommand extends Command {
 			d: "Mention, or type the ID of, the role that you want to make the Member role. Members will need this role to access the section (or the server).",
 			m: false,
 			mainMongo: "roles.raider",
-			sectMongo: "sections.$.roles.verifiedRole"
+			sectMongo: "sections.$.verifiedRole"
 		},
 		{
 			q: "Configure Team Role",
@@ -229,7 +229,7 @@ export class ConfigureSectionCommand extends Command {
 			d: "Mention, or type the ID of, the role that you want to make the Section Leader role. Section Trial Leaders will be able to start AFK checks in their designated sections with approval from a Raid Leader. **NOTE:** Sction trial leaders can only start AFK checks and headcounts in their designated sections.",
 			m: false,
 			mainMongo: "roles.mainSectionLeaderRole.sectionTrialLeaderRole",
-			sectMongo: "section.$.roles.trialLeaderRole"
+			sectMongo: "sections.$.roles.trialLeaderRole"
 		},
 		{
 			q: "Configure Support Role",
@@ -450,8 +450,8 @@ export class ConfigureSectionCommand extends Command {
 			$push: {
 				sections: {
 					nameOfSection: nameOfSection,
+					verifiedRole: verifiedRole.id,
 					roles: {
-						verifiedRole: verifiedRole.id,
 						trialLeaderRole: "",
 						raidLeaderRole: "",
 						almostLeaderRole: ""
@@ -511,7 +511,7 @@ export class ConfigureSectionCommand extends Command {
 
 		return (await MongoDbHelper.MongoDbGuildManager.MongoGuildClient.findOneAndUpdate({ guildID: (msg.guild as Guild).id }, {
 			$pull: {
-				"sections.verifiedRole": resp.roles.verifiedRole
+				"sections.verifiedRole": resp.verifiedRole
 			}
 		}, { returnOriginal: false })).value as IRaidGuild
 	}
@@ -637,7 +637,7 @@ export class ConfigureSectionCommand extends Command {
 				else {
 					// this part only handles channel modifications, not role modifications
 					// so we know that the role should be constant 
-					section = guildData.sections.find(x => x.roles.verifiedRole === section.roles.verifiedRole) as ISection;
+					section = guildData.sections.find(x => x.verifiedRole === section.verifiedRole) as ISection;
 				}
 				this.modifyMainMenu(msg, guildData, section, m, false);
 				return;
@@ -954,7 +954,7 @@ export class ConfigureSectionCommand extends Command {
 			else {
 				// this part only handles channel modifications, not role modifications
 				// so we know that the role should be constant 
-				section = res.sections.find(x => x.roles.verifiedRole === section.roles.verifiedRole) as ISection;
+				section = res.sections.find(x => x.verifiedRole === section.verifiedRole) as ISection;
 			}
 
 			this.sectionChannelMenuCommand(msg, res, section, botSentMsg, false, this.getStringRepOfGuildDoc(msg, section, res).channelSB.toString());
@@ -999,7 +999,7 @@ export class ConfigureSectionCommand extends Command {
 			.addField("Configure __Section__ Almost Leader Role", "React with 🏴 to configure the section almost leader role. Section almost leaders will be able to start AFK checks and headcounts in their respective sections only.")
 			.addField("Configure __Section__ Trial Leader Role", "React with 🚩 to configure the section trial leader role. Section trial leaders will be able to start AFK checks (after getting approval from a leader) in their respective section only.");
 
-		reactions.push("⬅️", "💳", "🏳️", "🏴", "‍🚩");
+		reactions.push("⬅️", "💳", "🏳️", "🏴", "🚩");
 
 		if (section.isMain) {
 			embed
@@ -1024,7 +1024,6 @@ export class ConfigureSectionCommand extends Command {
 		embed
 			.addField("Role Wizard", "React with 💾 to begin the role wizard. This is ideal if this is your first time fully customizing the section's roles.")
 		reactions.push("💾");
-
 		//#endregion
 
 		try {
@@ -1076,10 +1075,10 @@ export class ConfigureSectionCommand extends Command {
 					msg,
 					"Raider Role",
 					section,
-					guild.roles.cache.get(section.roles.verifiedRole),
+					guild.roles.cache.get(section.verifiedRole),
 					section.isMain
 						? "roles.raider"
-						: "sections.$.roles.verifiedRole"
+						: "sections.$.verifiedRole"
 				);
 			}
 			// moderator role
@@ -1420,7 +1419,7 @@ export class ConfigureSectionCommand extends Command {
 			else if (r.emoji.name === "🛡️") {
 				const filterQuery: FilterQuery<IRaidGuild> = section.isMain
 					? { guildID: guild.id }
-					: { guildID: guild.id, "sections.roles.verifiedRole": section.roles.verifiedRole };
+					: { guildID: guild.id, "sections.verifiedRole": section.verifiedRole };
 				const updateQuery: UpdateQuery<IRaidGuild> = section.isMain
 					? { $set: { "properties.showVerificationRequirements": !section.properties.showVerificationRequirements } }
 					: { $set: { "sections.$.properties.showVerificationRequirements": !section.properties.showVerificationRequirements } };
@@ -1498,7 +1497,7 @@ export class ConfigureSectionCommand extends Command {
 			else {
 				// this part only handles channel modifications, not role modifications
 				// so we know that the role should be constant 
-				section = res.sections.find(x => x.roles.verifiedRole === section.roles.verifiedRole) as ISection;
+				section = res.sections.find(x => x.verifiedRole === section.verifiedRole) as ISection;
 			}
 
 			this.sectionVerificationMenuCommand(msg, res, section, botSentMsg, false, this.getStringRepOfGuildDoc(msg, section, res).verifSB.toString());
@@ -1548,7 +1547,7 @@ export class ConfigureSectionCommand extends Command {
 					: section.verification.maxedStats.required;
 			const filterQuery: FilterQuery<IRaidGuild> = section.isMain
 				? { guildID: guild.id }
-				: { guildID: guild.id, "sections.roles.verifiedRole": section.roles.verifiedRole };
+				: { guildID: guild.id, "sections.verifiedRole": section.verifiedRole };
 			const updateQueryOnOff: UpdateQuery<IRaidGuild> = section.isMain
 				? { $set: { [mainMongoPath[0]]: !currentStatus } }
 				: { $set: { [sectMongoPath[0]]: !currentStatus } };
@@ -1597,7 +1596,7 @@ export class ConfigureSectionCommand extends Command {
 					else {
 						// this part only handles channel modifications, not role modifications
 						// so we know that the role should be constant 
-						section = guildData.sections.find(x => x.roles.verifiedRole === section.roles.verifiedRole) as ISection;
+						section = guildData.sections.find(x => x.verifiedRole === section.verifiedRole) as ISection;
 					}
 
 					this.sectionVerificationMenuCommand(msg, guildData, section, botMsg, false, this.getStringRepOfGuildDoc(msg, section, guildData).verifSB.toString());
@@ -1686,7 +1685,7 @@ export class ConfigureSectionCommand extends Command {
 					else {
 						// this part only handles channel modifications, not role modifications
 						// so we know that the role should be constant 
-						section = guildData.sections.find(x => x.roles.verifiedRole === section.roles.verifiedRole) as ISection;
+						section = guildData.sections.find(x => x.verifiedRole === section.verifiedRole) as ISection;
 					}
 
 					this.sectionVerificationMenuCommand(msg, guildData, section, botMsg, false, this.getStringRepOfGuildDoc(msg, section, guildData).verifSB.toString());
@@ -1733,7 +1732,7 @@ export class ConfigureSectionCommand extends Command {
 			return guildData;
 		}
 
-		guildData = (await MongoDbHelper.MongoDbGuildManager.MongoGuildClient.findOneAndUpdate({ guildID: guild.id, "sections.roles.verifiedRole": section.roles.verifiedRole }, {
+		guildData = (await MongoDbHelper.MongoDbGuildManager.MongoGuildClient.findOneAndUpdate({ guildID: guild.id, "sections.verifiedRole": section.verifiedRole }, {
 			$set: {
 				"sections.$.nameOfSection": result
 			}
@@ -1765,7 +1764,7 @@ export class ConfigureSectionCommand extends Command {
 
 		let query: FilterQuery<IRaidGuild> = section.isMain
 			? { guildID: guild.id }
-			: { guildID: guild.id, "sections.roles.verifiedRole": section.roles.verifiedRole }
+			: { guildID: guild.id, "sections.verifiedRole": section.verifiedRole }
 
 		let updateQuery: UpdateQuery<IRaidGuild> = {};
 		let update$set: { [key: string]: string } = {};
@@ -1835,7 +1834,7 @@ export class ConfigureSectionCommand extends Command {
 
 		let query: FilterQuery<IRaidGuild> = section.isMain
 			? { guildID: guild.id }
-			: { guildID: guild.id, "sections.roles.verifiedRole": section.roles.verifiedRole };
+			: { guildID: guild.id, "sections.verifiedRole": section.verifiedRole };
 
 		return (await MongoDbHelper.MongoDbGuildManager.MongoGuildClient.findOneAndUpdate(query, {
 			$set: {
@@ -1878,7 +1877,7 @@ export class ConfigureSectionCommand extends Command {
 
 		let query: FilterQuery<IRaidGuild> = section.isMain
 			? { guildID: guild.id }
-			: { guildID: guild.id, "sections.roles.verifiedRole": section.roles.verifiedRole };
+			: { guildID: guild.id, "sections.verifiedRole": section.verifiedRole };
 
 		return (await MongoDbHelper.MongoDbGuildManager.MongoGuildClient.findOneAndUpdate(query, {
 			$set: {
@@ -1921,7 +1920,7 @@ export class ConfigureSectionCommand extends Command {
 		for (let i = 0; i < configuredSections.length; i++) {
 			const afkCheckChannel: GuildChannel | undefined = guild.channels.cache.get(configuredSections[i].channels.afkCheckChannel);
 			const verificationChannel: GuildChannel | undefined = guild.channels.cache.get(configuredSections[i].channels.verificationChannel);
-			const verifiedRole: Role | undefined = guild.roles.cache.get(configuredSections[i].roles.verifiedRole);
+			const verifiedRole: Role | undefined = guild.roles.cache.get(configuredSections[i].verifiedRole);
 
 			removeEmbed.addField(`[${i + 1}] Section: ${configuredSections[i].nameOfSection}`, `Verified Role: ${typeof verifiedRole !== "undefined" ? verifiedRole : "Not Set."}
 AFK Check Channel: ${typeof afkCheckChannel !== "undefined" ? afkCheckChannel : "Not Set."}
@@ -1975,7 +1974,7 @@ Verification Channel: ${typeof verificationChannel !== "undefined" ? verificatio
 				if (reason === "SAVE") {
 					const filterQuery: FilterQuery<IRaidGuild> = section.isMain
 						? { guildID: guild.id }
-						: { guildID: guild.id, "sections.roles.verifiedRole": section.roles.verifiedRole };
+						: { guildID: guild.id, "sections.verifiedRole": section.verifiedRole };
 					const updateQuery: UpdateQuery<IRaidGuild> = section.isMain
 						? { $set: { "properties.dungeons": d.filter(x => x.isIncluded).map(x => x.data.id) } }
 						: { $set: { "sections.$.properties.dungeons": d.filter(x => x.isIncluded).map(x => x.data.id) } };
@@ -2113,7 +2112,7 @@ Verification Channel: ${typeof verificationChannel !== "undefined" ? verificatio
 		const raidRequestsChannel: GuildChannel | undefined = guild.channels.cache.get(guildData.generalChannels.raidRequestChannel);
 
 		// roles for section (only 1)
-		const verifiedRole: Role | undefined = guild.roles.cache.get(section.roles.verifiedRole);
+		const verifiedRole: Role | undefined = guild.roles.cache.get(section.verifiedRole);
 		const secRaidLeaderRole: Role | undefined = guild.roles.cache.get(section.roles.raidLeaderRole);
 		const secAlmostRaidLeaderRole: Role | undefined = guild.roles.cache.get(section.roles.almostLeaderRole);
 		const secTrialLeaderRole: Role | undefined = guild.roles.cache.get(section.roles.trialLeaderRole);

--- a/src/Commands/Configuration/ConfigureSectionCommand.ts
+++ b/src/Commands/Configuration/ConfigureSectionCommand.ts
@@ -197,25 +197,39 @@ export class ConfigureSectionCommand extends Command {
 			sectMongo: ""
 		},
 		{
-			q: "Configure Leader Role",
-			d: "Mention, or type the ID of, the role that you want to make the Leader role. Leaders will have the ability to suspend members.",
+			q: "Configure Universal Leader Role",
+			d: "Mention, or type the ID of, the role that you want to make the Universal Leader role. Leaders will have the ability to suspend members. **NOTE:** Universal Leaders have the ability to start AFK checks and headcounts in ANY section.",
 			m: true,
 			mainMongo: "roles.universalRaidLeader",
 			sectMongo: ""
 		},
 		{
-			q: "Configure Almost Leader Role",
-			d: "Mention, or type the ID of, the role that you want to make the Almost Leader role. Almost Leaders (ARLs) are leaders that have more experience than a Trial Leader but are not quite ready for the full responsibilities associated with being a Leader.",
+			q: "Configure Section Leader Role",
+			d: "Mention, or type the ID of, the role that you want to make the Section Leader role. Section Leaders will have the ability to suspend members. **NOTE:** Unlike universal leaders, section leaders can only start AFK checks and headcounts in their designated sections.",
+			m: false,
+			mainMongo: "roles.sectionLeaderRole",
+			sectMongo: "sections.$.roles.raidLeaderRole"
+		},
+		{
+			q: "Configure Universal Almost Leader Role",
+			d: "Mention, or type the ID of, the role that you want to make the Universal Almost Leader role. Almost Leaders (ARLs) are leaders that have more experience than a Trial Leader but are not quite ready for the full responsibilities associated with being a Leader. **NOTE:** Universal Almost Leaders have the ability to start AFK checks in ANY section.",
 			m: true,
 			mainMongo: "roles.universalAlmostRaidLeader",
 			sectMongo: ""
 		},
 		{
-			q: "Configure Trial Leader Role",
-			d: "Mention, or type the ID of, the role that you want to make the Trial Leader role. Trial Leaders are leaders that have just been promoted. They are unable to start runs on their own but can talk (and should lead) in raids.",
-			m: true,
-			mainMongo: "roles.trialRaidLeader",
-			sectMongo: ""
+			q: "Configure Section Almost Leader Role",
+			d: "Mention, or type the ID of, the role that you want to make the Section Almost Leader role. Section Almost Leaders are leaders that have more experience than a Section Trial Leader but are not quite ready for the full responsibilities associated with being a full-on Section Leader. **NOTE:** Unlike universal almost leaders, section almost leaders can only start AFK checks and headcounts in their designated sections.", // this sounds awkward to say out loud, doesn't it? 
+			m: false,
+			mainMongo: "roles.sectionAlmostLeader",
+			sectMongo: "sections.$.roles.sectionAlmostLeaderRole"
+		},
+		{
+			q: "Configure Section Trial Leader Role",
+			d: "Mention, or type the ID of, the role that you want to make the Section Leader role. Section Trial Leaders will be able to start AFK checks in their designated sections with approval from a Raid Leader. **NOTE:** Sction trial leaders can only start AFK checks and headcounts in their designated sections.",
+			m: false,
+			mainMongo: "roles.sectionTrialLeaderRole",
+			sectMongo: "section.$.roles.trialLeaderRole"
 		},
 		{
 			q: "Configure Support Role",
@@ -980,17 +994,20 @@ export class ConfigureSectionCommand extends Command {
 		//#region append channels to messageembed 
 		embed
 			.addField("Go Back", "React with ⬅️ to go back to the Main Menu.")
-			.addField("Configure Member Role", "React with 💳 to configure the Member/Verified role.");
+			.addField("Configure Member Role", "React with 💳 to configure the Member/Verified role.")
+			.addField("Configure __Section__ Leader Role", "React with 🏳️ to configure the section leader role. Section leaders will be able to start AFK checks and headcounts in their respective section only.")
+			.addField("Configure __Section__ Almost Leader Role", "React with 🏴 to configure the section almost leader role. Section almost leaders will be able to start AFK checks and headcounts in their respective sections only.")
+			.addField("Configure __Section__ Trial Leader Role", "React with 🚩 to configure the section trial leader role. Section trial leaders will be able to start AFK checks (after getting approval from a leader) in their respective section only.");
 
-		reactions.push("⬅️", "💳");
+		reactions.push("⬅️", "💳", "🏳️", "🏴", "‍🚩");
 
 		if (section.isMain) {
 			embed
 				.addField("Configure Team Role", "React with 👪 to configure the Team role.")
 				.addField("Configure Moderator Role", "React with ⚒️ to configure the Moderator role.")
 				.addField("Configure Head Leader Role", "React with 🥇 to configure the Head Leader role.")
-				.addField("Configure Leader Role", "React with 🥈 to configure the Leader role.")
-				.addField("Configure Almost Leader Role", "React with 🥉 to configure the Almost Leader role.")
+				.addField("Configure Universal Leader Role", "React with 🥈 to configure the Universal Leader role.")
+				.addField("Configure Universal Almost Leader Role", "React with 🥉 to configure the Universal Almost Leader role.")
 				.addField("Configure Support Role", "React with 📛 to configure the Support/Helper role.")
 				.addField("Configure Pardoned Leader Role", "React with 💤 to configure the Pardoned Leader role.")
 				.addField("Configure Suspended Role", "React with ⛔ to configure the Suspended role.")
@@ -1000,8 +1017,8 @@ export class ConfigureSectionCommand extends Command {
 			//.addField("Configure Tier II Key Role", "React with 🔑 to configure the Tier 2 Key Donator role.")
 			//.addField("Configure Tier III Key Role", "React with 🍀 to configure the Tier 3 Key Donator role.");
 
-			reactions.push("👪", "⚒️", "🥇", "🥈", "🥉", "📛", "💤", "⛔", "🔈", "🗺️"); 
-				// , "🔈", "🗝️", "🔑", "🍀"
+			reactions.push("👪", "⚒️", "🥇", "🥈", "🥉", "📛", "💤", "⛔", "🔈", "🗺️");
+			// , "🔈", "🗝️", "🔑", "🍀"
 		}
 
 		embed
@@ -1164,6 +1181,45 @@ export class ConfigureSectionCommand extends Command {
 					guildData.roles.earlyLocationRoles
 				);
 			}
+			// sec leader role
+			else if (r.emoji.name === "🏳️") {
+				await this.resetBotEmbed(botSentMsg).catch(() => { });
+				res = await this.updateRoleCommand(
+					msg,
+					"Section Leader Roles",
+					section,
+					guild.roles.cache.get(section.roles.raidLeaderRole),
+					section.isMain
+						? "roles.sectionLeaderRole"
+						: "sections.$.roles.raidLeaderRole"
+				);
+			}
+			// sec arl
+			else if (r.emoji.name === "🏴") {
+				await this.resetBotEmbed(botSentMsg).catch(() => { });
+				res = await this.updateRoleCommand(
+					msg,
+					"Section Almost Leader Roles",
+					section,
+					guild.roles.cache.get(section.roles.almostLeaderRole),
+					section.isMain
+						? "roles.sectionAlmostLeaderRole"
+						: "sections.$.roles.almostLeaderRole"
+				);
+			}
+			// sec trl
+			else if (r.emoji.name === "🚩") {
+				await this.resetBotEmbed(botSentMsg).catch(() => { });
+				res = await this.updateRoleCommand(
+					msg,
+					"Section Trial Leader Roles",
+					section,
+					guild.roles.cache.get(section.roles.trialLeaderRole),
+					section.isMain
+						? "roles.sectionTrialLeaderRole"
+						: "sections.$.roles.trialLeaderRole"
+				);
+			}
 			// configuration wizard
 			else if (r.emoji.name === "💾") {
 				res = await this.startWizard(msg, section, botSentMsg, this._roleQs, "ROLE");
@@ -1199,7 +1255,7 @@ export class ConfigureSectionCommand extends Command {
 	private async updateArrayRoleCommand(
 		msg: Message,
 		roleName: string,
-		guildData: IRaidGuild, 
+		guildData: IRaidGuild,
 		mongoPath: string,
 		currRoles: string[]
 	): Promise<IRaidGuild | "CANCEL" | "TIME"> {
@@ -1207,7 +1263,7 @@ export class ConfigureSectionCommand extends Command {
 		guildData = await this.removeDeadElements(guildData, currRoles, mongoPath, guild);
 
 		const roles: (Role | undefined)[] = currRoles.map(x => guild.roles.cache.get(x));
-		
+
 		const resolvedRole: Role[] = [];
 		for (const role of roles) {
 			if (typeof role !== "undefined") {
@@ -2286,7 +2342,7 @@ Verification Channel: ${typeof verificationChannel !== "undefined" ? verificatio
 	 * @param {Guild} guild The guild. 
 	 */
 	private async removeDeadElements(
-		guildDb: IRaidGuild, 
+		guildDb: IRaidGuild,
 		roleArray: string[],
 		field: string,
 		guild: Guild

--- a/src/Commands/Configuration/ConfigureSectionCommand.ts
+++ b/src/Commands/Configuration/ConfigureSectionCommand.ts
@@ -258,6 +258,7 @@ export class ConfigureSectionCommand extends Command {
 				["ADMINISTRATOR"],
 				["ADD_REACTIONS", "MANAGE_MESSAGES", "EMBED_LINKS"],
 				[],
+				[],
 				false
 			),
 			true,

--- a/src/Commands/Configuration/ConfigureSectionCommand.ts
+++ b/src/Commands/Configuration/ConfigureSectionCommand.ts
@@ -2114,6 +2114,9 @@ Verification Channel: ${typeof verificationChannel !== "undefined" ? verificatio
 
 		// roles for section (only 1)
 		const verifiedRole: Role | undefined = guild.roles.cache.get(section.roles.verifiedRole);
+		const secRaidLeaderRole: Role | undefined = guild.roles.cache.get(section.roles.raidLeaderRole);
+		const secAlmostRaidLeaderRole: Role | undefined = guild.roles.cache.get(section.roles.almostLeaderRole);
+		const secTrialLeaderRole: Role | undefined = guild.roles.cache.get(section.roles.trialLeaderRole);
 
 		// roles for the guild
 		const teamRole: Role | undefined = guild.roles.cache.get(guildData.roles.teamRole);
@@ -2170,6 +2173,12 @@ Verification Channel: ${typeof verificationChannel !== "undefined" ? verificatio
 		const roleSB: StringBuilder = new StringBuilder("__Role__")
 			.appendLine()
 			.append(`Verified Role: ${typeof verifiedRole === "undefined" ? "N/A" : verifiedRole}`)
+			.appendLine()
+			.append(`Section Leader Role: ${typeof secRaidLeaderRole === "undefined" ? "N/A" : secRaidLeaderRole}`)
+			.appendLine()
+			.append(`Section Almost Leader Role: ${typeof secAlmostRaidLeaderRole === "undefined" ? "N/A" : secAlmostRaidLeaderRole}`)
+			.appendLine()
+			.append(`Section Trial Leader Role: ${typeof secTrialLeaderRole === "undefined" ? "N/A" : secTrialLeaderRole}`);
 
 		const verificationSB: StringBuilder = new StringBuilder("__Verification__")
 			.appendLine()

--- a/src/Commands/Moderator/BlacklistCommand.ts
+++ b/src/Commands/Moderator/BlacklistCommand.ts
@@ -28,6 +28,7 @@ export class BlacklistCommand extends Command {
 				["BAN_MEMBERS", "MANAGE_GUILD"],
 				["BAN_MEMBERS", "EMBED_LINKS"],
 				["officer", "moderator"],
+				[],
 				false
 			),
 			true,

--- a/src/Commands/Moderator/BlacklistCommand.ts
+++ b/src/Commands/Moderator/BlacklistCommand.ts
@@ -65,6 +65,7 @@ export class BlacklistCommand extends Command {
 			await MessageUtil.send({ content: `The reason you provided is too long; your reasoning is ${reason.length} characters long, and the maximum length is 500 characters.` }, msg.channel);
 			return;
 		}
+		
 		const memberToBlacklist: GuildMember | null = await UserHandler.resolveMember(msg, guildDb);
 
 		// check to see if in server 

--- a/src/Commands/Moderator/BlacklistCommand.ts
+++ b/src/Commands/Moderator/BlacklistCommand.ts
@@ -27,7 +27,7 @@ export class BlacklistCommand extends Command {
 			new CommandPermission(
 				["BAN_MEMBERS", "MANAGE_GUILD"],
 				["BAN_MEMBERS", "EMBED_LINKS"],
-				["officer", "moderator"],
+				["officer", "moderator", "headRaidLeader"],
 				[],
 				false
 			),

--- a/src/Commands/Moderator/MuteCommand.ts
+++ b/src/Commands/Moderator/MuteCommand.ts
@@ -26,6 +26,7 @@ export class MuteCommand extends Command {
 				["MUTE_MEMBERS"],
 				["MANAGE_CHANNELS", "MANAGE_ROLES", "EMBED_LINKS"],
 				["support", "headRaidLeader", "officer", "moderator"],
+				[],
 				false
 			),
 			true,

--- a/src/Commands/Moderator/SuspendCommand.ts
+++ b/src/Commands/Moderator/SuspendCommand.ts
@@ -25,6 +25,7 @@ export class SuspendCommand extends Command {
 				["KICK_MEMBERS"],
 				["MANAGE_ROLES", "EMBED_LINKS"],
 				["universalRaidLeader", "headRaidLeader", "officer", "moderator"],
+				["SECTION_RL"],
 				false
 			),
 			true,

--- a/src/Commands/Moderator/SuspendCommand.ts
+++ b/src/Commands/Moderator/SuspendCommand.ts
@@ -24,7 +24,7 @@ export class SuspendCommand extends Command {
 			new CommandPermission(
 				["KICK_MEMBERS"],
 				["MANAGE_ROLES", "EMBED_LINKS"],
-				["raidLeader", "headRaidLeader", "officer", "moderator"],
+				["universalRaidLeader", "headRaidLeader", "officer", "moderator"],
 				false
 			),
 			true,

--- a/src/Commands/Moderator/UnblacklistCommand.ts
+++ b/src/Commands/Moderator/UnblacklistCommand.ts
@@ -26,6 +26,7 @@ export class UnblacklistCommand extends Command {
 				["BAN_MEMBERS", "MANAGE_GUILD"],
                 ["BAN_MEMBERS", "EMBED_LINKS"],
                 ["officer", "moderator"],
+                [],
                 false
             ),
             true,

--- a/src/Commands/Moderator/UnblacklistCommand.ts
+++ b/src/Commands/Moderator/UnblacklistCommand.ts
@@ -25,7 +25,7 @@ export class UnblacklistCommand extends Command {
             new CommandPermission(
 				["BAN_MEMBERS", "MANAGE_GUILD"],
                 ["BAN_MEMBERS", "EMBED_LINKS"],
-                ["officer", "moderator"],
+                ["officer", "moderator", "headRaidLeader"],
                 [],
                 false
             ),

--- a/src/Commands/Moderator/UnmuteCommand.ts
+++ b/src/Commands/Moderator/UnmuteCommand.ts
@@ -23,7 +23,8 @@ export class UnmuteCommand extends Command {
 			new CommandPermission(
                 ["MUTE_MEMBERS"],
 				["MANAGE_ROLES", "EMBED_LINKS"],
-				["support", "headRaidLeader", "officer", "moderator"],
+                ["support", "headRaidLeader", "officer", "moderator"],
+                [],
 				false
 			),
 			true,

--- a/src/Commands/Moderator/UnsuspendCommand.ts
+++ b/src/Commands/Moderator/UnsuspendCommand.ts
@@ -24,7 +24,7 @@ export class UnsuspendCommand extends Command {
 			new CommandPermission(
                 ["KICK_MEMBERS"],
                 ["MANAGE_ROLES", "EMBED_LINKS"],
-				["raidLeader", "headRaidLeader", "officer", "moderator"],
+				["universalRaidLeader", "headRaidLeader", "officer", "moderator"],
 				false
 			),
 			true,

--- a/src/Commands/Moderator/UnsuspendCommand.ts
+++ b/src/Commands/Moderator/UnsuspendCommand.ts
@@ -24,7 +24,8 @@ export class UnsuspendCommand extends Command {
 			new CommandPermission(
                 ["KICK_MEMBERS"],
                 ["MANAGE_ROLES", "EMBED_LINKS"],
-				["universalRaidLeader", "headRaidLeader", "officer", "moderator"],
+                ["universalRaidLeader", "headRaidLeader", "officer", "moderator"],
+                ["SECTION_RL"],
 				false
 			),
 			true,

--- a/src/Commands/Public/HelpCommand.ts
+++ b/src/Commands/Public/HelpCommand.ts
@@ -75,9 +75,7 @@ export class HelpCommand extends Command {
                     "moderator",
                     "headRaidLeader",
                     "officer",
-                    "raidLeader",
-                    "almostRaidLeader",
-                    "trialRaidLeader",
+                    "universalRaidLeader",
                     "support",
                     "raider",
                     "suspended"

--- a/src/Commands/Public/HelpCommand.ts
+++ b/src/Commands/Public/HelpCommand.ts
@@ -23,6 +23,7 @@ export class HelpCommand extends Command {
                 [],
                 [],
                 ["raider"],
+                [],
                 true
             ),
             false, // guild-only command. 

--- a/src/Commands/Public/UserManagerCommand.ts
+++ b/src/Commands/Public/UserManagerCommand.ts
@@ -35,6 +35,7 @@ export class UserManagerCommand extends Command {
 				[],
 				[],
 				["suspended"],
+				[],
 				true
 			),
 			false, // guild-only command. 

--- a/src/Commands/Raid Leader/LogRaidCommand.ts
+++ b/src/Commands/Raid Leader/LogRaidCommand.ts
@@ -22,7 +22,7 @@ export class LogRaidCommand extends Command {
 			new CommandPermission(
 				[],
 				["EMBED_LINKS"],
-				["trialRaidLeader"],
+				[],
 				true
 			),
 			true, // guild-only command. 

--- a/src/Commands/Raid Leader/LogRaidCommand.ts
+++ b/src/Commands/Raid Leader/LogRaidCommand.ts
@@ -23,6 +23,7 @@ export class LogRaidCommand extends Command {
 				[],
 				["EMBED_LINKS"],
 				[],
+				[],
 				true
 			),
 			true, // guild-only command. 

--- a/src/Commands/Raid Leader/StartAfkCheckCommand.ts
+++ b/src/Commands/Raid Leader/StartAfkCheckCommand.ts
@@ -20,7 +20,7 @@ export class StartAfkCheckCommand extends Command {
 			new CommandPermission(
 				[],
 				["MANAGE_CHANNELS", "ADD_REACTIONS", "EMBED_LINKS"],
-				["headRaidLeader", "raidLeader", "almostRaidLeader", "trialRaidLeader"],
+				["headRaidLeader", "universalRaidLeader", "universalAlmostRaidLeader"],
 				false
 			),
 			true,

--- a/src/Commands/Raid Leader/StartAfkCheckCommand.ts
+++ b/src/Commands/Raid Leader/StartAfkCheckCommand.ts
@@ -21,6 +21,7 @@ export class StartAfkCheckCommand extends Command {
 				[],
 				["MANAGE_CHANNELS", "ADD_REACTIONS", "EMBED_LINKS"],
 				["headRaidLeader", "universalRaidLeader", "universalAlmostRaidLeader"],
+				["ALL_RL_TYPE"],
 				false
 			),
 			true,

--- a/src/Commands/Raid Leader/StartHeadcountCommand.ts
+++ b/src/Commands/Raid Leader/StartHeadcountCommand.ts
@@ -21,6 +21,7 @@ export class StartHeadcountCommand extends Command {
 				[],
 				["ADD_REACTIONS", "EMBED_LINKS"],
 				["headRaidLeader", "universalRaidLeader", "universalAlmostRaidLeader"],
+				["ALL_RL_TYPE"],
 				false
 			),
 			true,

--- a/src/Commands/Raid Leader/StartHeadcountCommand.ts
+++ b/src/Commands/Raid Leader/StartHeadcountCommand.ts
@@ -20,7 +20,7 @@ export class StartHeadcountCommand extends Command {
 			new CommandPermission(
 				[],
 				["ADD_REACTIONS", "EMBED_LINKS"],
-				["headRaidLeader", "raidLeader", "almostRaidLeader", "trialRaidLeader"],
+				["headRaidLeader", "universalRaidLeader", "universalAlmostRaidLeader"],
 				false
 			),
 			true,

--- a/src/Commands/Staff/CheckBlacklistCommand.ts
+++ b/src/Commands/Staff/CheckBlacklistCommand.ts
@@ -27,6 +27,7 @@ export class CheckBlacklistCommand extends Command {
 				[],
 				["EMBED_LINKS"],
 				["support"],
+				[],
 				true
 			),
 			true, // guild-only command. 

--- a/src/Commands/Staff/FindUserCommand.ts
+++ b/src/Commands/Staff/FindUserCommand.ts
@@ -25,7 +25,7 @@ export class FindUserCommand extends Command {
 			new CommandPermission(
 				[],
 				["EMBED_LINKS"],
-				["support"],
+				["verifier"],
 				[],
 				true
 			),

--- a/src/Commands/Staff/FindUserCommand.ts
+++ b/src/Commands/Staff/FindUserCommand.ts
@@ -26,6 +26,7 @@ export class FindUserCommand extends Command {
 				[],
 				["EMBED_LINKS"],
 				["support"],
+				[],
 				true
 			),
 			true, // guild-only command. 

--- a/src/Commands/Staff/ManualVerifyCommand.ts
+++ b/src/Commands/Staff/ManualVerifyCommand.ts
@@ -39,6 +39,7 @@ export class ManualVerifyCommand extends Command {
                 [],
                 ["EMBED_LINKS"],
                 ["support", "headRaidLeader", "officer", "moderator", "officer"],
+                [],
                 false
             ),
             true, // guild-only command. 

--- a/src/Commands/Staff/ManualVerifyCommand.ts
+++ b/src/Commands/Staff/ManualVerifyCommand.ts
@@ -58,7 +58,7 @@ export class ManualVerifyCommand extends Command {
             const allSections: ISection[] = [GuildUtil.getDefaultSection(guildData), ...guildData.sections];
             for (const section of allSections) {
                 const verifiedRole: Role | undefined = guild.roles.cache
-                    .get(section.verifiedRole);
+                    .get(section.roles.verifiedRole);
 
                 if (typeof verifiedRole === "undefined") {
                     continue;
@@ -213,7 +213,7 @@ export class ManualVerifyCommand extends Command {
             const allSections: ISection[] = [GuildUtil.getDefaultSection(guildData), ...guildData.sections];
             for (const section of allSections) {
                 const verifiedRole: Role | undefined = guild.roles.cache
-                    .get(section.verifiedRole);
+                    .get(section.roles.verifiedRole);
 
                 if (typeof verifiedRole === "undefined") {
                     continue;

--- a/src/Commands/Staff/ManualVerifyCommand.ts
+++ b/src/Commands/Staff/ManualVerifyCommand.ts
@@ -38,7 +38,7 @@ export class ManualVerifyCommand extends Command {
             new CommandPermission(
                 [],
                 ["EMBED_LINKS"],
-                ["support", "headRaidLeader", "officer", "moderator", "officer"],
+                ["support", "headRaidLeader", "officer", "moderator", "officer", "verifier"],
                 [],
                 false
             ),

--- a/src/Commands/Staff/ManualVerifyCommand.ts
+++ b/src/Commands/Staff/ManualVerifyCommand.ts
@@ -59,7 +59,7 @@ export class ManualVerifyCommand extends Command {
             const allSections: ISection[] = [GuildUtil.getDefaultSection(guildData), ...guildData.sections];
             for (const section of allSections) {
                 const verifiedRole: Role | undefined = guild.roles.cache
-                    .get(section.roles.verifiedRole);
+                    .get(section.verifiedRole);
 
                 if (typeof verifiedRole === "undefined") {
                     continue;
@@ -214,7 +214,7 @@ export class ManualVerifyCommand extends Command {
             const allSections: ISection[] = [GuildUtil.getDefaultSection(guildData), ...guildData.sections];
             for (const section of allSections) {
                 const verifiedRole: Role | undefined = guild.roles.cache
-                    .get(section.roles.verifiedRole);
+                    .get(section.verifiedRole);
 
                 if (typeof verifiedRole === "undefined") {
                     continue;

--- a/src/Commands/Staff/PollCommand.ts
+++ b/src/Commands/Staff/PollCommand.ts
@@ -143,6 +143,7 @@ export class PollCommand extends Command {
 				[],
 				["ADD_REACTIONS", "EMBED_LINKS"],
 				["support"],
+				[],
 				true
 			),
 			true, // guild-only command. 

--- a/src/Commands/Staff/SendEmbedCommand.ts
+++ b/src/Commands/Staff/SendEmbedCommand.ts
@@ -38,6 +38,7 @@ export class SendEmbedCommand extends Command {
 				[],
 				["ADD_REACTIONS", "EMBED_LINKS"],
 				["headRaidLeader"],
+				[],
 				true
 			),
 			true, // guild-only command. 

--- a/src/Commands/Test/TestCommand.ts
+++ b/src/Commands/Test/TestCommand.ts
@@ -22,6 +22,7 @@ export class TestCommand extends Command {
 				[],
 				[],
 				[],
+				[],
 				false
 			),
 			false, // guild-only command. 

--- a/src/Definitions/ISection.ts
+++ b/src/Definitions/ISection.ts
@@ -15,13 +15,16 @@ export interface ISection {
 	 */
 	isMain: boolean;
 
+	/**
+	 * The role needed for access to this section.
+	 * Also the way to search for this section.
+	 */
+	verifiedRole: string;
 
+	/**
+	 * Other roles
+	 */
 	roles: {
-		/**
-		 * The role needed for access to this section.
-		 */
-		verifiedRole: string;
-
 		/**
 		 * Raid leader role.
 		 */
@@ -30,12 +33,12 @@ export interface ISection {
 		/**
 		 * Almost leader role.
 		 */
-		almostLeaderRole: string; 
+		almostLeaderRole: string;
 
 		/**
 		 * Trial leader role.
 		 */
-		trialLeaderRole: string; 
+		trialLeaderRole: string;
 	}
 
 	/**

--- a/src/Definitions/ISection.ts
+++ b/src/Definitions/ISection.ts
@@ -15,10 +15,28 @@ export interface ISection {
 	 */
 	isMain: boolean;
 
-	/**
-	 * The role needed for access to this section.
-	 */
-	verifiedRole: string;
+
+	roles: {
+		/**
+		 * The role needed for access to this section.
+		 */
+		verifiedRole: string;
+
+		/**
+		 * Raid leader role.
+		 */
+		raidLeaderRole: string;
+
+		/**
+		 * Almost leader role.
+		 */
+		almostLeaderRole: string; 
+
+		/**
+		 * Trial leader role.
+		 */
+		trialLeaderRole: string; 
+	}
 
 	/**
 	 * Channels for the group.

--- a/src/Definitions/Types.ts
+++ b/src/Definitions/Types.ts
@@ -1,4 +1,12 @@
 /**
  * Represents the possible role types for a guild.
  */
-export type RoleNames = "suspended" | "raider" | "pardonedRaidLeader" | "support" | "trialRaidLeader" | "almostRaidLeader" | "raidLeader" | "officer" | "headRaidLeader" | "moderator";
+export type RoleNames = "suspended" 
+    | "raider" 
+    | "pardonedRaidLeader" 
+    | "support"
+    | "universalAlmostRaidLeader" 
+    | "universalRaidLeader"
+    | "officer" 
+    | "headRaidLeader" 
+    | "moderator";

--- a/src/Definitions/Types.ts
+++ b/src/Definitions/Types.ts
@@ -4,6 +4,7 @@
 export type RoleNames = "suspended"
     | "raider"
     | "pardonedRaidLeader"
+    | "verifier" // lowest "legit" staff role
     | "support"
     | "trialLeader"
     | "universalAlmostRaidLeader"

--- a/src/Definitions/Types.ts
+++ b/src/Definitions/Types.ts
@@ -1,12 +1,18 @@
 /**
  * Represents the possible role types for a guild.
  */
-export type RoleNames = "suspended" 
-    | "raider" 
-    | "pardonedRaidLeader" 
+export type RoleNames = "suspended"
+    | "raider"
+    | "pardonedRaidLeader"
     | "support"
-    | "universalAlmostRaidLeader" 
+    | "trialLeader"
+    | "universalAlmostRaidLeader"
     | "universalRaidLeader"
-    | "officer" 
-    | "headRaidLeader" 
+    | "officer"
+    | "headRaidLeader"
     | "moderator";
+
+export type LeaderPermType = "SECTION_RL"
+    | "SECTION_ARL"
+    | "SECTION_TRL"
+    | "ALL_RL_TYPE";

--- a/src/Events/Error.ts
+++ b/src/Events/Error.ts
@@ -1,0 +1,7 @@
+import { DateUtil } from "../Utility/DateUtil";
+
+export async function onError(error: Error): Promise<void> {
+    console.error(`[EVENT] ERROR OCCURRED AT: ${DateUtil.getTime()}`);
+    console.error(error);
+    console.log("=====================");
+}

--- a/src/Events/GuildMemberUpdate.ts
+++ b/src/Events/GuildMemberUpdate.ts
@@ -7,7 +7,6 @@ export async function onGuildMemberUpdate(
     oldMember: GuildMember | PartialGuildMember,
     newMember: GuildMember | PartialGuildMember
 ): Promise<void> {
-    const resolvedOldMember: GuildMember = await oldMember.fetch();
     const resolvedNewMember: GuildMember = await newMember.fetch();
 
     const guild: Guild = oldMember.guild;

--- a/src/Events/MessageEvent.ts
+++ b/src/Events/MessageEvent.ts
@@ -133,9 +133,8 @@ async function commandHandler(msg: Message, guildHandler: IRaidGuild | null): Pr
 		if (command.getRolePermissions().length !== 0
 			&& !member.permissions.has("ADMINISTRATOR")) {
 			const raider: string = guildHandler.roles.raider;
-			const trialRaidLeader: string = guildHandler.roles.trialRaidLeader;
-			const almostRaidLeader: string = guildHandler.roles.almostRaidLeader;
-			const raidLeader: string = guildHandler.roles.raidLeader;
+			const universalAlmostRaidLeader: string = guildHandler.roles.universalAlmostRaidLeader;
+			const universalRaidLeader: string = guildHandler.roles.universalRaidLeader;
 			const officer: string = guildHandler.roles.officer;
 			const headRaidLeader: string = guildHandler.roles.headRaidLeader;
 			const moderator: string = guildHandler.roles.moderator;
@@ -145,9 +144,8 @@ async function commandHandler(msg: Message, guildHandler: IRaidGuild | null): Pr
 				[moderator, "moderator"],
 				[headRaidLeader, "headRaidLeader"],
 				[officer, "officer"],
-				[raidLeader, "raidLeader"],
-				[almostRaidLeader, "almostRaidLeader"],
-				[trialRaidLeader, "trialRaidLeader"],
+				[universalRaidLeader, "universalRaidLeader"],
+				[universalAlmostRaidLeader, "universalAlmostRaidLeader"],
 				[support, "support"],
 				[raider, "raider"],
 				[suspended, "suspended"]

--- a/src/Events/MessageEvent.ts
+++ b/src/Events/MessageEvent.ts
@@ -7,6 +7,8 @@ import { RoleNames } from "../Definitions/Types";
 import { StringUtil } from "../Utility/StringUtil";
 import { MongoDbHelper } from "../Helpers/MongoDbHelper";
 import { MessageUtil } from "../Utility/MessageUtil";
+import { ISection } from "../Definitions/ISection";
+import { GuildUtil } from "../Utility/GuildUtil";
 
 export async function onMessageEvent(msg: Message) {
 	// make sure we have a regular message to handle
@@ -132,6 +134,9 @@ async function commandHandler(msg: Message, guildHandler: IRaidGuild | null): Pr
 		// check to see if the member has role perms
 		if (command.getRolePermissions().length !== 0
 			&& !member.permissions.has("ADMINISTRATOR")) {
+			const allSections: ISection[] = [GuildUtil.getDefaultSection(guildHandler), ...guildHandler.sections];
+
+			// role define
 			const raider: string = guildHandler.roles.raider;
 			const universalAlmostRaidLeader: string = guildHandler.roles.universalAlmostRaidLeader;
 			const universalRaidLeader: string = guildHandler.roles.universalRaidLeader;
@@ -140,16 +145,45 @@ async function commandHandler(msg: Message, guildHandler: IRaidGuild | null): Pr
 			const moderator: string = guildHandler.roles.moderator;
 			const support: string = guildHandler.roles.support;
 			const suspended: string = guildHandler.roles.suspended;
+			// rl
 			const roleOrder: [string, RoleNames][] = [
 				[moderator, "moderator"],
 				[headRaidLeader, "headRaidLeader"],
 				[officer, "officer"],
 				[universalRaidLeader, "universalRaidLeader"],
-				[universalAlmostRaidLeader, "universalAlmostRaidLeader"],
+			];
+
+			if (command.getSecRLAccountType().includes("ALL_RL_TYPE")
+				|| command.getSecRLAccountType().includes("SECTION_RL")) {
+				// rl
+				for (const sec of allSections) {
+					roleOrder.push([sec.roles.raidLeaderRole, "universalRaidLeader"]);
+				}
+			}
+
+			roleOrder.push([universalAlmostRaidLeader, "universalAlmostRaidLeader"]);
+			if (command.getSecRLAccountType().includes("ALL_RL_TYPE")
+				|| command.getSecRLAccountType().includes("SECTION_ARL")) {
+				// arl
+				for (const sec of allSections) {
+					roleOrder.push([sec.roles.almostLeaderRole, "universalAlmostRaidLeader"]);
+				}
+			}
+
+			if (command.getSecRLAccountType().includes("ALL_RL_TYPE")
+				|| command.getSecRLAccountType().includes("SECTION_TRL")) {
+				// trl
+				for (const sec of allSections) {
+					roleOrder.push([sec.roles.trialLeaderRole, "trialLeader"]);
+				}
+			}
+
+			// add the rest of the roles.
+			roleOrder.push(
 				[support, "support"],
 				[raider, "raider"],
 				[suspended, "suspended"]
-			];
+			);
 
 			let canRunCommand: boolean = false;
 

--- a/src/Events/MessageEvent.ts
+++ b/src/Events/MessageEvent.ts
@@ -174,7 +174,7 @@ async function commandHandler(msg: Message, guildHandler: IRaidGuild | null): Pr
 				|| command.getSecRLAccountType().includes("SECTION_TRL")) {
 				// trl
 				for (const sec of allSections) {
-					roleOrder.push([sec.roles.trialLeaderRole, "trialLeader"]);
+					roleOrder.push([sec.roles.trialLeaderRole, "universalAlmostRaidLeader"]); // for now
 				}
 			}
 

--- a/src/Events/MessageEvent.ts
+++ b/src/Events/MessageEvent.ts
@@ -144,6 +144,7 @@ async function commandHandler(msg: Message, guildHandler: IRaidGuild | null): Pr
 			const headRaidLeader: string = guildHandler.roles.headRaidLeader;
 			const moderator: string = guildHandler.roles.moderator;
 			const support: string = guildHandler.roles.support;
+			const verifier: string = guildHandler.roles.verifier;
 			const suspended: string = guildHandler.roles.suspended;
 			// rl
 			const roleOrder: [string, RoleNames][] = [
@@ -181,6 +182,7 @@ async function commandHandler(msg: Message, guildHandler: IRaidGuild | null): Pr
 			// add the rest of the roles.
 			roleOrder.push(
 				[support, "support"],
+				[verifier, "verifier"],
 				[raider, "raider"],
 				[suspended, "suspended"]
 			);

--- a/src/Events/MessageEvent.ts
+++ b/src/Events/MessageEvent.ts
@@ -214,7 +214,6 @@ async function commandHandler(msg: Message, guildHandler: IRaidGuild | null): Pr
 						}
 					}
 				}
-
 			}
 
 			if (!canRunCommand) {

--- a/src/Events/MessageReactionAddEvent.ts
+++ b/src/Events/MessageReactionAddEvent.ts
@@ -184,12 +184,14 @@ export async function onMessageReactionAdd(
 
         // let's check headcounts first
         if (reaction.message.embeds[0].footer.text === "Control Panel • Headcount Ended"
-            && reaction.emoji.name === "🗑️") {
+            && reaction.emoji.name === "🗑️"
+            && (member.roles.cache.some(x => leaderRoles.includes(x.id)) || member.hasPermission("ADMINISTRATOR"))) {
             await reaction.message.delete().catch(() => { });
             return;
         }
 
-        if (reaction.message.embeds[0].footer.text.includes("Control Panel • Headcount")) {
+        if (reaction.message.embeds[0].footer.text.includes("Control Panel • Headcount")
+            && (member.roles.cache.some(x => leaderRoles.includes(x.id)) || member.hasPermission("ADMINISTRATOR"))) {
             // remember that there can only be one headcount per section
             const headCountData: IHeadCountInfo | undefined = guildDb.activeRaidsAndHeadcounts.headcounts
                 .find(x => x.section.channels.controlPanelChannel === reaction.message.channel.id);
@@ -217,8 +219,8 @@ export async function onMessageReactionAdd(
             // afk check
             if (reaction.message.embeds[0].footer.text.includes("Control Panel • AFK Check")
                 && raidFromReaction.status === RaidStatus.AFKCheck) {
-
-                if (member.roles.cache.some(x => leaderRoles.includes(x.id))) {
+                if (member.roles.cache.some(x => leaderRoles.includes(x.id))
+                    || member.hasPermission("ADMINISTRATOR")) {
                     // end afk
                     if (reaction.emoji.name === "⏹️") {
                         RaidHandler.endAfkCheck(guildDb, guild, raidFromReaction, member.voice.channel, member);
@@ -233,7 +235,8 @@ export async function onMessageReactionAdd(
                     }
                 }
 
-                if (member.roles.cache.some(x => [...staffRoles, ...leaderRoles].includes(x.id))) {
+                if (member.roles.cache.some(x => [...staffRoles, ...leaderRoles].includes(x.id))
+                    || member.hasPermission("ADMINISTRATOR")) {
                     // get loc
                     if (reaction.emoji.name === "🗺️") {
                         user.send(`**\`[${guild.name} ⇒ ${sectionFromControlPanel.nameOfSection} ⇒ Raiding ${raidFromReaction.raidNum}]\`** The location of this raid is: \`${raidFromReaction.location}\``);
@@ -243,7 +246,8 @@ export async function onMessageReactionAdd(
             // in raid
             else if (reaction.message.embeds[0].footer.text.includes("Control Panel • In Raid")
                 && raidFromReaction.status === RaidStatus.InRun) {
-                if (member.roles.cache.some(x => leaderRoles.includes(x.id))) {
+                if (member.roles.cache.some(x => leaderRoles.includes(x.id))
+                    || member.hasPermission("ADMINISTRATOR")) {
                     // end run
                     if (reaction.emoji.name === "⏹️") {
                         RaidHandler.endRun(member, guild, raidFromReaction);
@@ -266,7 +270,8 @@ export async function onMessageReactionAdd(
                     }
                 }
 
-                if (member.roles.cache.some(x => [...staffRoles, ...leaderRoles].includes(x.id))) {
+                if (member.roles.cache.some(x => [...staffRoles, ...leaderRoles].includes(x.id))
+                    || member.hasPermission("ADMINISTRATOR")) {
                     // get loc
                     if (reaction.emoji.name === "🗺️") {
                         user.send(`**\`[${guild.name} ⇒ ${sectionFromControlPanel.nameOfSection} ⇒ Raiding ${raidFromReaction.raidNum}]\`** The location of this raid is: \`${raidFromReaction.location}\``);

--- a/src/Events/MessageReactionAddEvent.ts
+++ b/src/Events/MessageReactionAddEvent.ts
@@ -100,7 +100,7 @@ export async function onMessageReactionAdd(
             const manualVerifMember: GuildMember | undefined = guild.members.cache
                 .get(manualVerificationProfile.userId);
             const sectionVerifiedRole: Role | undefined = guild.roles.cache
-                .get(sectionForManualVerif.roles.verifiedRole);
+                .get(sectionForManualVerif.verifiedRole);
 
             if (typeof manualVerifMember === "undefined" || typeof sectionVerifiedRole === "undefined") {
                 return; // GuildMemberRemove should auto take care of this
@@ -142,10 +142,10 @@ export async function onMessageReactionAdd(
             return;
         }
         else {
-            if (!member.roles.cache.has(sectionForVerification.roles.verifiedRole)) {
+            if (!member.roles.cache.has(sectionForVerification.verifiedRole)) {
                 return;
             }
-            await member.roles.remove(sectionForVerification.roles.verifiedRole).catch(() => { });
+            await member.roles.remove(sectionForVerification.verifiedRole).catch(() => { });
             await member.send(`**\`[${guild.name}]\`**: You have successfully been unverified from the **\`${sectionForVerification.nameOfSection}\`** section!`);
             if (typeof verificationSuccessChannel !== "undefined") {
                 verificationSuccessChannel.send(`📤 **\`[${sectionForVerification.nameOfSection}]\`** ${member} has been unverified from the section.`).catch(() => { });

--- a/src/Events/MessageReactionAddEvent.ts
+++ b/src/Events/MessageReactionAddEvent.ts
@@ -235,8 +235,7 @@ export async function onMessageReactionAdd(
                     }
                 }
 
-                if (member.roles.cache.some(x => [...staffRoles, ...leaderRoles].includes(x.id))
-                    || member.hasPermission("ADMINISTRATOR")) {
+                if (member.roles.cache.has(guildDb.roles.teamRole) || member.hasPermission("ADMINISTRATOR")) {
                     // get loc
                     if (reaction.emoji.name === "🗺️") {
                         user.send(`**\`[${guild.name} ⇒ ${sectionFromControlPanel.nameOfSection} ⇒ Raiding ${raidFromReaction.raidNum}]\`** The location of this raid is: \`${raidFromReaction.location}\``);
@@ -270,8 +269,7 @@ export async function onMessageReactionAdd(
                     }
                 }
 
-                if (member.roles.cache.some(x => [...staffRoles, ...leaderRoles].includes(x.id))
-                    || member.hasPermission("ADMINISTRATOR")) {
+                if (member.roles.cache.has(guildDb.roles.teamRole) || member.hasPermission("ADMINISTRATOR")) {
                     // get loc
                     if (reaction.emoji.name === "🗺️") {
                         user.send(`**\`[${guild.name} ⇒ ${sectionFromControlPanel.nameOfSection} ⇒ Raiding ${raidFromReaction.raidNum}]\`** The location of this raid is: \`${raidFromReaction.location}\``);

--- a/src/Events/MessageReactionAddEvent.ts
+++ b/src/Events/MessageReactionAddEvent.ts
@@ -102,7 +102,7 @@ export async function onMessageReactionAdd(
             const manualVerifMember: GuildMember | undefined = guild.members.cache
                 .get(manualVerificationProfile.userId);
             const sectionVerifiedRole: Role | undefined = guild.roles.cache
-                .get(sectionForManualVerif.verifiedRole);
+                .get(sectionForManualVerif.roles.verifiedRole);
 
             if (typeof manualVerifMember === "undefined" || typeof sectionVerifiedRole === "undefined") {
                 return; // GuildMemberRemove should auto take care of this
@@ -144,10 +144,10 @@ export async function onMessageReactionAdd(
             return;
         }
         else {
-            if (!member.roles.cache.has(sectionForVerification.verifiedRole)) {
+            if (!member.roles.cache.has(sectionForVerification.roles.verifiedRole)) {
                 return;
             }
-            await member.roles.remove(sectionForVerification.verifiedRole).catch(e => { });
+            await member.roles.remove(sectionForVerification.roles.verifiedRole).catch(e => { });
             await member.send(`**\`[${guild.name}]\`**: You have successfully been unverified from the **\`${sectionForVerification.nameOfSection}\`** section!`);
             if (typeof verificationSuccessChannel !== "undefined") {
                 verificationSuccessChannel.send(`📤 **\`[${sectionForVerification.nameOfSection}]\`** ${member} has been unverified from the section.`).catch(e => { });
@@ -166,9 +166,8 @@ export async function onMessageReactionAdd(
     }
 
     const leaderRoles: RoleResolvable[] = [
-        guildDb.roles.trialRaidLeader,
-        guildDb.roles.almostRaidLeader,
-        guildDb.roles.raidLeader,
+        guildDb.roles.universalAlmostRaidLeader,
+        guildDb.roles.universalRaidLeader,
         guildDb.roles.headRaidLeader
     ];
 

--- a/src/Events/ReadyEvent.ts
+++ b/src/Events/ReadyEvent.ts
@@ -80,13 +80,5 @@ export async function onReadyEvent() {
  * Preloads any new data. Make sure to update this before running! :) 
  */
 async function mongoPreloader(): Promise<void> {
-	await MongoDbHelper.MongoDbGuildManager.MongoGuildClient.updateMany({}, {
-		$set: {
-			"roles.mainSectionLeaderRole": {
-				sectionLeaderRole: "",
-				sectionAlmostLeaderRole: "", 
-				sectionTrialLeaderRole: ""
-			}
-		}
-	});
+	
 }

--- a/src/Events/ReadyEvent.ts
+++ b/src/Events/ReadyEvent.ts
@@ -5,10 +5,10 @@ import { Zero } from "../Zero";
 import { MuteCommand } from "../Commands/Moderator/MuteCommand";
 import { SuspendCommand } from "../Commands/Moderator/SuspendCommand";
 import { IRaidBot } from "../Templates/IRaidBot";
-import { InsertOneWriteOpResult, WithId } from "mongodb";
 import { DateUtil } from "../Utility/DateUtil";
 
 export async function onReadyEvent() {
+	await mongoPreloader();
 	const guildBots: string[] = [];
 	for await (let [id, guild] of Zero.RaidClient.guilds.cache) {
 		guildBots.push(id);
@@ -74,4 +74,19 @@ export async function onReadyEvent() {
 	let app: ClientApplication = await Zero.RaidClient.fetchApplication();
 	let owner: User = await Zero.RaidClient.users.fetch((app.owner as User).id);
 	console.log('\x1b[36m%s\x1b[0m', `${(Zero.RaidClient.user as ClientUser).tag} has started.\nBOT TAG: ${(Zero.RaidClient.user as ClientUser).tag}\nBOT ID: ${(Zero.RaidClient.user as ClientUser).id}\nOWNER TAG: ${owner.tag}\nOWNER ID: ${owner.id}\nTIME: ${DateUtil.getTime()}`);
+}
+
+/**
+ * Preloads any new data. Make sure to update this before running! :) 
+ */
+async function mongoPreloader(): Promise<void> {
+	await MongoDbHelper.MongoDbGuildManager.MongoGuildClient.updateMany({}, {
+		$set: {
+			"roles.mainSectionLeaderRole": {
+				sectionLeaderRole: "",
+				sectionAlmostLeaderRole: "", 
+				sectionTrialLeaderRole: ""
+			}
+		}
+	});
 }

--- a/src/Helpers/MongoDbHelper.ts
+++ b/src/Helpers/MongoDbHelper.ts
@@ -227,6 +227,7 @@ export module MongoDbHelper {
 						universalRaidLeader: "",
 						universalAlmostRaidLeader: "",
 						support: "",
+						verifier: "",
 						pardonedRaidLeader: "",
 						raider: "",
 						suspended: "",

--- a/src/Helpers/MongoDbHelper.ts
+++ b/src/Helpers/MongoDbHelper.ts
@@ -224,9 +224,8 @@ export module MongoDbHelper {
 						moderator: "",
 						headRaidLeader: "",
 						officer: "",
-						raidLeader: "",
-						almostRaidLeader: "",
-						trialRaidLeader: "",
+						universalRaidLeader: "",
+						universalAlmostRaidLeader: "",
 						support: "",
 						pardonedRaidLeader: "",
 						raider: "",
@@ -247,7 +246,10 @@ export module MongoDbHelper {
 								role: "",
 								min: 0
 							}
-						}
+						},
+						sectionAlmostLeaderRole: "",
+						sectionLeaderRole: "",
+						sectionTrialLeaderRole: ""
 					},
 					properties: {
 						successfulVerificationMessage: "",

--- a/src/Helpers/MongoDbHelper.ts
+++ b/src/Helpers/MongoDbHelper.ts
@@ -247,9 +247,11 @@ export module MongoDbHelper {
 								min: 0
 							}
 						},
-						sectionAlmostLeaderRole: "",
-						sectionLeaderRole: "",
-						sectionTrialLeaderRole: ""
+						mainSectionLeaderRole: {
+							sectionAlmostLeaderRole: "",
+							sectionLeaderRole: "",
+							sectionTrialLeaderRole: ""
+						}
 					},
 					properties: {
 						successfulVerificationMessage: "",

--- a/src/Helpers/RaidDbHelper.ts
+++ b/src/Helpers/RaidDbHelper.ts
@@ -209,13 +209,11 @@ export module RaidDbHelper {
 			return new Promise((resolve, reject) => {
 				if (!guild.channels.cache.has(section.channels.afkCheckChannel)
 					|| !guild.channels.cache.has(section.channels.verificationChannel)
-					|| !guild.roles.cache.has(section.verifiedRole)
+					|| !guild.roles.cache.has(section.roles.verifiedRole)
 				) {
 					MongoDbHelper.MongoDbGuildManager.MongoGuildClient.updateOne({ guildID: guild.id }, {
 						$pull: {
-							sections: {
-								verifiedRole: section.verifiedRole
-							}
+							"sections.roles": section.roles.verifiedRole
 						}
 					}, (err: any, raw: any) => {
 						if (err) {

--- a/src/Helpers/RaidDbHelper.ts
+++ b/src/Helpers/RaidDbHelper.ts
@@ -209,11 +209,11 @@ export module RaidDbHelper {
 			return new Promise((resolve, reject) => {
 				if (!guild.channels.cache.has(section.channels.afkCheckChannel)
 					|| !guild.channels.cache.has(section.channels.verificationChannel)
-					|| !guild.roles.cache.has(section.roles.verifiedRole)
+					|| !guild.roles.cache.has(section.verifiedRole)
 				) {
 					MongoDbHelper.MongoDbGuildManager.MongoGuildClient.updateOne({ guildID: guild.id }, {
 						$pull: {
-							"sections.roles": section.roles.verifiedRole
+							"sections.roles": section.verifiedRole
 						}
 					}, (err: any, raw: any) => {
 						if (err) {

--- a/src/Helpers/RaidHandler.ts
+++ b/src/Helpers/RaidHandler.ts
@@ -1531,6 +1531,7 @@ export module RaidHandler {
 				let max: number = min;
 
 				const embed: MessageEmbed = new MessageEmbed()
+					.setAuthor(msg.author.tag, msg.author.displayAvatarURL())
 					.setTitle("⚙️ Select a Raid Section")
 					.setDescription("Your server contains multiple raiding sections. Please select the appropriate section.")
 					.setFooter(guild.name)

--- a/src/Helpers/RaidHandler.ts
+++ b/src/Helpers/RaidHandler.ts
@@ -351,7 +351,7 @@ export module RaidHandler {
 				deny: ["VIEW_CHANNEL", "SPEAK"]
 			},
 			{
-				id: SECTION.roles.verifiedRole,
+				id: SECTION.verifiedRole,
 				allow: ["VIEW_CHANNEL"]
 			},
 			{

--- a/src/Helpers/RaidHandler.ts
+++ b/src/Helpers/RaidHandler.ts
@@ -982,10 +982,10 @@ export module RaidHandler {
 		const initiator: GuildMember | null = guild.member(rs.startedBy);
 		let descStr: string = `Control panel commands will only work if you are in the corresponding voice channel. Below are details regarding the raid.\nRaid Section: ${rs.section.nameOfSection}\nInitiator: ${initiator === null ? "Unknown" : initiator} (${initiator === null ? "Unknown" : initiator.displayName})\nDungeon: ${rs.dungeonInfo.dungeonName} ${Zero.RaidClient.emojis.cache.get(rs.dungeonInfo.portalEmojiID)}\nVoice Channel: Raiding ${rs.raidNum}`;
 		if (peopleThatGotLocEarly.length !== 0) {
-			descStr += `\n\nEarly Locations: ${peopleThatGotLocEarly.join(" ")}`;
+			descStr += `\n\n__**Early Locations**__\n${peopleThatGotLocEarly.join(" ")}`;
 		}
 		if (getStringRepOfKeyCollection(peopleThatReactedToKey, rs).length !== 0) {
-			descStr += getStringRepOfKeyCollection(peopleThatReactedToKey, rs);
+			descStr += `\n\n__**Key Reacts**__\n${getStringRepOfKeyCollection(peopleThatReactedToKey, rs)}`;
 		}
 		const startRunControlPanelEmbed: MessageEmbed = new MessageEmbed()
 			.setAuthor(`Control Panel: Raiding ${rs.raidNum}`, rs.dungeonInfo.portalLink)
@@ -1418,7 +1418,7 @@ export module RaidHandler {
 
 		await hcMsg.edit(newEmbed).catch(() => { });
 		await hcMsg.unpin().catch(() => { });
-		await hcMsg.reactions.removeAll().catch(() => { });
+		await controlPanelMessage.reactions.removeAll().catch(() => { });
 		await controlPanelMessage.edit(newControlPanelEmbed).catch(() => { });
 		await controlPanelMessage.react("🗑️").catch(() => { });
 		setTimeout(async () => {

--- a/src/Helpers/RaidHandler.ts
+++ b/src/Helpers/RaidHandler.ts
@@ -248,7 +248,7 @@ export module RaidHandler {
 					// make sure he or she has a leader/higher-up role
 					const allowsRoles: string[] = [
 						guildDb.roles.headRaidLeader,
-						guildDb.roles.raidLeader,
+						guildDb.roles.universalRaidLeader,
 						guildDb.roles.moderator,
 						guildDb.roles.officer
 					];
@@ -341,7 +341,7 @@ export module RaidHandler {
 				deny: ["VIEW_CHANNEL", "SPEAK"]
 			},
 			{
-				id: SECTION.verifiedRole,
+				id: SECTION.roles.verifiedRole,
 				allow: ["VIEW_CHANNEL"]
 			},
 			{
@@ -349,15 +349,11 @@ export module RaidHandler {
 				allow: ["VIEW_CHANNEL", "CONNECT", "MOVE_MEMBERS"]
 			},
 			{
-				id: guildDb.roles.trialRaidLeader,
+				id: guildDb.roles.universalAlmostRaidLeader,
 				allow: ["VIEW_CHANNEL", "CONNECT", "SPEAK"]
 			},
 			{
-				id: guildDb.roles.almostRaidLeader,
-				allow: ["VIEW_CHANNEL", "CONNECT", "SPEAK"]
-			},
-			{
-				id: guildDb.roles.raidLeader,
+				id: guildDb.roles.universalRaidLeader,
 				allow: ["VIEW_CHANNEL", "CONNECT", "SPEAK", "MUTE_MEMBERS", "MOVE_MEMBERS"]
 			},
 			{
@@ -877,7 +873,7 @@ export module RaidHandler {
 				// if they were not found in the list of reactions
 				// AND they are not a staff member 
 				if (!(isFound
-					|| member.roles.cache.some(x => [guildDb.roles.raidLeader, guildDb.roles.trialRaidLeader, guildDb.roles.headRaidLeader, guildDb.roles.moderator, guildDb.roles.almostRaidLeader, guildDb.roles.officer].includes(x.id)))) {
+					|| member.roles.cache.some(x => [guildDb.roles.universalRaidLeader, guildDb.roles.headRaidLeader, guildDb.roles.moderator, guildDb.roles.universalAlmostRaidLeader, guildDb.roles.officer].includes(x.id)))) {
 					member.voice.setChannel(loungeVC).catch(() => { });
 				}
 			}

--- a/src/Helpers/RaidHandler.ts
+++ b/src/Helpers/RaidHandler.ts
@@ -484,7 +484,7 @@ export module RaidHandler {
 		// ==================================
 		// control panel stuff
 		// ==================================
-		const controlPanelDescription: string = `Control panel commands will only work if you are in the corresponding voice channel. Below are details regarding the AFK check.\nRaid Section: ${SECTION.nameOfSection}\nInitiator: ${member} (${member.displayName})\nDungeon: ${SELECTED_DUNGEON.dungeonName} ${Zero.RaidClient.emojis.cache.get(SELECTED_DUNGEON.portalEmojiID)}\nVoice Channel: Raiding ${newRaidNum}`;
+		const controlPanelDescription: string = `Control panel commands will only work if you are in the corresponding voice channel. Below are details regarding the AFK check.\n⇒ Raid Section: ${SECTION.nameOfSection}\n⇒ Initiator: ${member} (${member.displayName})\n⇒ Dungeon: ${SELECTED_DUNGEON.dungeonName} ${Zero.RaidClient.emojis.cache.get(SELECTED_DUNGEON.portalEmojiID)}\n⇒ Voice Channel: Raiding ${newRaidNum}`;
 		const controlPanelEmbed: MessageEmbed = new MessageEmbed()
 			.setAuthor(`Control Panel: Raiding ${newRaidNum}`, SELECTED_DUNGEON.portalLink)
 			.setDescription(controlPanelDescription)
@@ -1541,7 +1541,7 @@ export module RaidHandler {
 				const embed: MessageEmbed = new MessageEmbed()
 					.setAuthor(msg.author.tag, msg.author.displayAvatarURL())
 					.setTitle("⚙️ Select a Raid Section")
-					.setDescription("Your server contains multiple raiding sections. Please select the appropriate section.\n\n__Symbols__\n☑️ means you have the appropriate permission to start a run or headcount in the associated section.\n❌ means you do not have permission to start a run or headcount in the associated section.")
+					.setDescription("Your server contains multiple raiding sections. Please select the appropriate section by typing the number associated with the section you want to start an AFK check or headcount in.\n\n__Symbols__\n☑️ means you have the appropriate permission to start a run or headcount in the associated section.\n❌ means you do not have permission to start a run or headcount in the associated section.")
 					.setFooter(guild.name)
 					.setColor("RANDOM");
 				for (const section of sections) {
@@ -1558,7 +1558,7 @@ export module RaidHandler {
 						// we want a category associated with the afk check channel
 						if (sectionParent !== null) {
 							embed.addFields({
-								name: `${max}: ${sectionParent.name} ${hasPermission ? "☑️" : "❌"}`,
+								name: `**[${max}]** ${section.nameOfSection} ${hasPermission ? "☑️" : "❌"}`,
 								value: `AFK Check Channel: ${afkCheckChannel}`
 							});
 							max++;

--- a/src/Helpers/UserHandler.ts
+++ b/src/Helpers/UserHandler.ts
@@ -3,6 +3,7 @@ import { IRaidGuild } from "../Templates/IRaidGuild";
 import Collection from "@discordjs/collection";
 import { StringUtil } from "../Utility/StringUtil";
 import { Zero } from "../Zero";
+import { GuildUtil } from "../Utility/GuildUtil";
 
 export namespace UserHandler {
 	/**
@@ -26,6 +27,11 @@ export namespace UserHandler {
 			guildData.roles.universalAlmostRaidLeader,
 			guildData.roles.officer
 		];
+
+		// get each individual section rl roles
+		for (const section of [GuildUtil.getDefaultSection(guildData), ...guildData.sections]) {
+			staffRoles.push(section.roles.almostLeaderRole, section.roles.raidLeaderRole, section.roles.trialLeaderRole);
+		}
 		
 		const allStaffRoles: Role[] = [];
 		for (const role of staffRoles) {

--- a/src/Helpers/UserHandler.ts
+++ b/src/Helpers/UserHandler.ts
@@ -21,10 +21,9 @@ export namespace UserHandler {
         let staffRoles: string[] = [
             guildData.roles.moderator,
             guildData.roles.headRaidLeader,
-			guildData.roles.raidLeader,
-			guildData.roles.trialRaidLeader,
+			guildData.roles.universalRaidLeader,
             guildData.roles.support,
-			guildData.roles.almostRaidLeader,
+			guildData.roles.universalAlmostRaidLeader,
 			guildData.roles.officer
 		];
 		

--- a/src/Helpers/UserHandler.ts
+++ b/src/Helpers/UserHandler.ts
@@ -21,11 +21,13 @@ export namespace UserHandler {
 
         let staffRoles: string[] = [
             guildData.roles.moderator,
-            guildData.roles.headRaidLeader,
+			guildData.roles.headRaidLeader,
+			guildData.roles.officer,
 			guildData.roles.universalRaidLeader,
-            guildData.roles.support,
 			guildData.roles.universalAlmostRaidLeader,
-			guildData.roles.officer
+			guildData.roles.support,
+			guildData.roles.verifier,
+			guildData.roles.pardonedRaidLeader
 		];
 
 		// get each individual section rl roles

--- a/src/Helpers/VerificationHandler.ts
+++ b/src/Helpers/VerificationHandler.ts
@@ -1202,6 +1202,14 @@ export module VerificationHandler {
 		}
 	}
 
+	/**
+	 * A function that should be executed when a manual verification application has been accepted.
+	 * @param {GuildMember} manualVerifMember The member to be manually verified.
+	 * @param {GuildMember} responsibleMember The member that manually verified `manualVerifMember`.
+	 * @param {ISection} sectionForManualVerif The section where the manual verification occurred.
+	 * @param {IManualVerification} manualVerificationProfile The manual verification profile.
+	 * @param {IRaidGuild} guildDb The guild doc.
+	 */
 	export async function acceptManualVerification(
 		manualVerifMember: GuildMember,
 		responsibleMember: GuildMember,
@@ -1210,7 +1218,7 @@ export module VerificationHandler {
 		guildDb: IRaidGuild
 	): Promise<void> {
 		const guild: Guild = manualVerifMember.guild;
-		let loggingMsg: string = `✅ **\`[${sectionForManualVerif.nameOfSection}]\`** ${manualVerifMember} has been manually verified as ${manualVerificationProfile.inGameName}. This manual verification was done by ${responsibleMember} (${responsibleMember.displayName})`;
+		let loggingMsg: string = `✅ **\`[${sectionForManualVerif.nameOfSection}]\`** ${manualVerifMember} has been manually verified as \`${manualVerificationProfile.inGameName}\`. This manual verification was done by ${responsibleMember} (${responsibleMember.displayName})`;
 
 		await manualVerifMember.roles.add(sectionForManualVerif.verifiedRole).catch(e => { });
 		if (sectionForManualVerif.isMain) {
@@ -1240,6 +1248,13 @@ export module VerificationHandler {
 		sendLogAndUpdateDb(loggingMsg, sectionForManualVerif, manualVerifMember);
 	}
 
+	/**
+	 * A function that should be executed when a manual verification application has been denied.
+	 * @param {GuildMember} manualVerifMember The member whose manual verification application has been denied.
+	 * @param {GuildMember} responsibleMember The member that denied `manualVerifMember`'s manual verification application.
+	 * @param {ISection} sectionForManualVerif The section where the manual verification occurred.
+	 * @param {IManualVerification} manualVerificationProfile The manual verification profile.
+	 */
 	export async function denyManualVerification(
 		manualVerifMember: GuildMember,
 		responsibleMember: GuildMember,
@@ -1259,6 +1274,12 @@ export module VerificationHandler {
 		sendLogAndUpdateDb(loggingMsg, sectionForManualVerif, manualVerifMember);
 	}
 
+	/**
+	 * Updates the db and logs the manual verification event.
+	 * @param {string} logging The message to send to the logging channel. 
+	 * @param {ISection} sectionForManualVerif The section where the person tried to get manually verified. 
+	 * @param {GuildMember} manualVerifMember The member that tried to get a manual verification. 
+	 */
 	async function sendLogAndUpdateDb(
 		logging: string,
 		sectionForManualVerif: ISection,

--- a/src/Helpers/VerificationHandler.ts
+++ b/src/Helpers/VerificationHandler.ts
@@ -55,11 +55,11 @@ export module VerificationHandler {
 	): Promise<void> {
 		try {
 			// already verified or no role
-			if (!guild.roles.cache.has(section.roles.verifiedRole) || member.roles.cache.has(section.roles.verifiedRole)) {
+			if (!guild.roles.cache.has(section.verifiedRole) || member.roles.cache.has(section.verifiedRole)) {
 				return;
 			}
 
-			const verifiedRole: Role = guild.roles.cache.get(section.roles.verifiedRole) as Role;
+			const verifiedRole: Role = guild.roles.cache.get(section.verifiedRole) as Role;
 			const dmChannel: DMChannel = await member.user.createDM();
 
 			// channel declaration
@@ -1236,7 +1236,7 @@ export module VerificationHandler {
 		const guild: Guild = manualVerifMember.guild;
 		let loggingMsg: string = `✅ **\`[${sectionForManualVerif.nameOfSection}]\`** ${manualVerifMember} has been manually verified as \`${manualVerificationProfile.inGameName}\`. This manual verification was done by ${responsibleMember} (${responsibleMember.displayName})`;
 
-		await manualVerifMember.roles.add(sectionForManualVerif.roles.verifiedRole).catch(e => { });
+		await manualVerifMember.roles.add(sectionForManualVerif.verifiedRole).catch(e => { });
 		if (sectionForManualVerif.isMain) {
 			await manualVerifMember.setNickname(manualVerificationProfile.inGameName).catch(e => { });
 			await VerificationHandler.accountInDatabase(

--- a/src/Helpers/VerificationHandler.ts
+++ b/src/Helpers/VerificationHandler.ts
@@ -55,11 +55,11 @@ export module VerificationHandler {
 	): Promise<void> {
 		try {
 			// already verified or no role
-			if (!guild.roles.cache.has(section.verifiedRole) || member.roles.cache.has(section.verifiedRole)) {
+			if (!guild.roles.cache.has(section.roles.verifiedRole) || member.roles.cache.has(section.roles.verifiedRole)) {
 				return;
 			}
 
-			const verifiedRole: Role = guild.roles.cache.get(section.verifiedRole) as Role;
+			const verifiedRole: Role = guild.roles.cache.get(section.roles.verifiedRole) as Role;
 			const dmChannel: DMChannel = await member.user.createDM();
 
 			// channel declaration
@@ -1128,10 +1128,26 @@ export module VerificationHandler {
 			await accountInDatabase(member, verificationInfo.name, nameHistoryInfo);
 		}
 
+		const desc: StringBuilder = new StringBuilder()
+			.append(`⇒ **Section:** ${section.nameOfSection}`)
+			.appendLine()
+			.append(`⇒ **User:** ${member}`)
+			.appendLine()
+			.append(`⇒ **IGN:** ${verificationInfo.name}`)
+			.appendLine()
+			.append(`⇒ **First Seen**: ${verificationInfo.created}`)
+			.appendLine()
+			.append(`⇒ **Last Seen**: ${verificationInfo.last_seen}`)
+			.appendLine()
+			.append(`⇒ **RealmEye:** [Profile](https://www.realmeye.com/player/${verificationInfo.name})`)
+			.appendLine()
+			.appendLine()
+			.append(`React with ☑️ to manually verify this person; otherwise, react with ❌.`)
+
 		const manualVerifEmbed: MessageEmbed = new MessageEmbed()
 			.setAuthor(member.user.tag, member.user.displayAvatarURL())
 			.setTitle(`Manual Verification Request: **${verificationInfo.name}**`)
-			.setDescription(`⇒ **Section:** ${section.nameOfSection}\n ⇒ **User:** ${member}\n⇒ **IGN:** ${verificationInfo.name}\n⇒ **RealmEye:** [Profile](https://www.realmeye.com/player/${verificationInfo.name})\n\nReact with ☑️ to manually verify this person; otherwise, react with ❌.\n\nIf the bot doesn't respond after you react, wait 5 seconds and then un-react & re-react.`)
+			.setDescription(desc.toString())
 			.addField("Unmet Requirements", StringUtil.applyCodeBlocks(reqsFailedToMeet.toString()), true)
 			.setColor("YELLOW")
 			.setFooter(member.id)
@@ -1220,7 +1236,7 @@ export module VerificationHandler {
 		const guild: Guild = manualVerifMember.guild;
 		let loggingMsg: string = `✅ **\`[${sectionForManualVerif.nameOfSection}]\`** ${manualVerifMember} has been manually verified as \`${manualVerificationProfile.inGameName}\`. This manual verification was done by ${responsibleMember} (${responsibleMember.displayName})`;
 
-		await manualVerifMember.roles.add(sectionForManualVerif.verifiedRole).catch(e => { });
+		await manualVerifMember.roles.add(sectionForManualVerif.roles.verifiedRole).catch(e => { });
 		if (sectionForManualVerif.isMain) {
 			await manualVerifMember.setNickname(manualVerificationProfile.inGameName).catch(e => { });
 			await VerificationHandler.accountInDatabase(

--- a/src/Helpers/VerificationHandler.ts
+++ b/src/Helpers/VerificationHandler.ts
@@ -1238,7 +1238,10 @@ export module VerificationHandler {
 
 		await manualVerifMember.roles.add(sectionForManualVerif.verifiedRole).catch(e => { });
 		if (sectionForManualVerif.isMain) {
-			await manualVerifMember.setNickname(manualVerificationProfile.inGameName).catch(e => { });
+			await manualVerifMember.setNickname(manualVerifMember.user.username === manualVerificationProfile.inGameName
+				? `${manualVerificationProfile.inGameName}.`
+				: manualVerificationProfile.inGameName
+			).catch(e => { });
 			await VerificationHandler.accountInDatabase(
 				manualVerifMember,
 				manualVerificationProfile.inGameName,

--- a/src/Templates/Command/Command.ts
+++ b/src/Templates/Command/Command.ts
@@ -1,5 +1,5 @@
 import { CommandDetail } from "./CommandDetail";
-import { CommandPermission } from "./CommandPermission";
+import { CommandPermission, LeaderPermType } from "./CommandPermission";
 import { Message, PermissionResolvable } from "discord.js";
 import { IRaidGuild } from "../IRaidGuild";
 import { RoleNames } from "../../Definitions/Types";
@@ -162,6 +162,14 @@ export abstract class Command {
 	 */
 	public isBotOwnerOnly(): boolean {
 		return this._botOwnerOnly;
+	}
+
+	/**
+	 * Which other non-universal RLs can use this command.
+	 * @returns {LeaderPermType[]} 
+	 */
+	public getSecRLAccountType(): LeaderPermType[] {
+		return this._commandPermissions.sectionRLAccountType();
 	}
 
 	/**

--- a/src/Templates/Command/Command.ts
+++ b/src/Templates/Command/Command.ts
@@ -1,8 +1,8 @@
 import { CommandDetail } from "./CommandDetail";
-import { CommandPermission, LeaderPermType } from "./CommandPermission";
+import { CommandPermission } from "./CommandPermission";
 import { Message, PermissionResolvable } from "discord.js";
 import { IRaidGuild } from "../IRaidGuild";
-import { RoleNames } from "../../Definitions/Types";
+import { RoleNames, LeaderPermType } from "../../Definitions/Types";
 
 export abstract class Command {
 	/**

--- a/src/Templates/Command/CommandPermission.ts
+++ b/src/Templates/Command/CommandPermission.ts
@@ -1,10 +1,5 @@
-import { RoleNames } from "../../Definitions/Types";
+import { RoleNames, LeaderPermType } from "../../Definitions/Types";
 import { PermissionResolvable } from "discord.js";
-
-export type LeaderPermType = "SECTION_RL"
-	| "SECTION_ARL"
-	| "SECTION_TRL"
-	| "ALL_RL_TYPE";
 
 export class CommandPermission {
 	/**

--- a/src/Templates/Command/CommandPermission.ts
+++ b/src/Templates/Command/CommandPermission.ts
@@ -1,6 +1,11 @@
 import { RoleNames } from "../../Definitions/Types";
 import { PermissionResolvable } from "discord.js";
 
+export type LeaderPermType = "SECTION_RL"
+	| "SECTION_ARL"
+	| "SECTION_TRL"
+	| "ALL_RL_TYPE";
+
 export class CommandPermission {
 	/**
 	 * Any general permissions that the user has to have in order to execute the command. This will take priority over `rolePermissions`. 
@@ -25,21 +30,29 @@ export class CommandPermission {
 	private roleInclusive: boolean;
 
 	/**
+	 * Which other non-universal RLs can use this command.
+	 */
+	private secRLType: LeaderPermType[];
+
+	/**
 	 * The constructor for this class.
 	 * @param {PermissionResolvable[]} generalPermissions Any general permissions that the user has to have in order to execute the command.
 	 * @param {RoleNames[]} rolePermissions The list of roles that can use this command.
+	 * @param {LeaderPermType} accountForSectionLeaderRoles Which other non-universal RLs can use this command.
 	 * @param {boolean} roleInclusive  Whether the command can be used by higher roles (higher than the highest listed role in `rolePermissions`).
 	 */
 	public constructor(
 		generalPermissions: PermissionResolvable[],
 		botPermissions: PermissionResolvable[],
 		rolePermissions: RoleNames[],
+		secRLType: LeaderPermType[],
 		roleInclusive: boolean
 	) {
 		this.generalPermissions = generalPermissions;
 		this.botPermissions = botPermissions;
 		this.rolePermissions = rolePermissions;
 		this.roleInclusive = roleInclusive;
+		this.secRLType = secRLType;
 	}
 	
 	/**
@@ -72,5 +85,13 @@ export class CommandPermission {
 	 */
 	public getBotPermissions(): PermissionResolvable[] {
 		return this.botPermissions;
+	}
+
+	/**
+	 * Which other non-universal RLs can use this command.
+	 * @returns {LeaderType} 
+	 */
+	public sectionRLAccountType(): LeaderPermType[] {
+		return this.secRLType;
 	}
 }

--- a/src/Templates/IRaidGuild.ts
+++ b/src/Templates/IRaidGuild.ts
@@ -76,6 +76,11 @@ export interface IRaidGuild {
 		support: string;
 
 		/**
+		 * The verifier role. Verifiers will have access to the find and manualverify command.
+		 */
+		verifier: string;
+
+		/**
 		 * The pardoned raid leader role. Pardoned raid leaders are on break from leading.
 		 * 
 		 * Names for this role may include, but are not limited to: Pardoned Raid Leader, Leader on Leave.

--- a/src/Templates/IRaidGuild.ts
+++ b/src/Templates/IRaidGuild.ts
@@ -59,21 +59,14 @@ export interface IRaidGuild {
 		 * 
 		 * Names for this role may include, but are not limited to: Raid Leader. 
 		 */
-		raidLeader: string;
+		universalRaidLeader: string;
 
 		/**
 		 * The almost raid leader role. 
 		 * 
 		 * Names for this role may include, but are not limited to: Trial Raid Leader.
 		 */
-		almostRaidLeader: string;
-
-		/**
-		 * The trial raid leader role. Trial raid leaders are new raid leaders and will have access to most of the commands Raid Leaders will have EXCEPT for the ability to start raids. 
-		 * 
-		 * Names for this role may include, but are not limited to: Trial Raid Leader.
-		 */
-		trialRaidLeader: string;
+		universalAlmostRaidLeader: string;
 
 		/**
 		 * The support role. Support is in charge of server management (think, a "lesser" version of moderators). 
@@ -145,7 +138,11 @@ export interface IRaidGuild {
 				role: string;
 				min: number;
 			}
-		}
+		};
+
+		sectionLeaderRole: string;
+		sectionAlmostLeaderRole: string; 
+		sectionTrialLeaderRole: string;
 	};
 
 	/**
@@ -276,7 +273,7 @@ export interface IRaidGuild {
 	/**
 	 * The prefix users can use to invoke bot commands.
 	 */
-	prefix: string
+	prefix: string;
 
 	/**
 	 * These are mini-sections of a server, where AFK checks and verification will be separate from the main process. Some "sections" could be, for example, "Veteran Raids," "Event Raids," etc.

--- a/src/Templates/IRaidGuild.ts
+++ b/src/Templates/IRaidGuild.ts
@@ -140,9 +140,14 @@ export interface IRaidGuild {
 			}
 		};
 
-		sectionLeaderRole: string;
-		sectionAlmostLeaderRole: string; 
-		sectionTrialLeaderRole: string;
+		/**
+		 * Section leader roles.
+		 */
+		mainSectionLeaderRole: {
+			sectionLeaderRole: string;
+			sectionAlmostLeaderRole: string; 
+			sectionTrialLeaderRole: string;
+		}
 	};
 
 	/**

--- a/src/Utility/GuildUtil.ts
+++ b/src/Utility/GuildUtil.ts
@@ -1,7 +1,101 @@
 import { IRaidGuild } from "../Templates/IRaidGuild";
 import { ISection } from "../Definitions/ISection";
+import { Guild, Collection, Role, GuildMember } from "discord.js";
+import { RoleNames } from "../Definitions/Types";
 
 export namespace GuildUtil { 
+	export type RaidLeaderRole = null | "TRL" | "ARL" | "RL" | "HRL";
+	export type RaidLeaderStatus = {
+		isUniversal: boolean; // this will override any other setting
+		sectionVerifiedRole: string;
+		highestLeaderRole: string;
+		roleType: RaidLeaderRole;
+	};
+
+	/**
+	 * Gets basic details about a leader. Only use this function to determine whether a RL can start AFK checks, needs approval, etc. 
+	 * @param {GuildMember} member The member. THE MEMBER MUST HAVE A LEADER ROLE OF SOME SORT FIRST!
+	 * @param {IRaidGuild} guildData The guild doc
+	 * @param {ISection} section The section where the command was executed
+	 * @returns {boolean} True if the leader can start AFK check without approval.
+	 */
+	export function getRaidLeaderStatus(
+		member: GuildMember, 
+		guildData: IRaidGuild, 
+		section: ISection
+	): RaidLeaderStatus {
+		const allowedRoles: string[] = [
+			guildData.roles.headRaidLeader,
+			guildData.roles.universalRaidLeader,
+			guildData.roles.universalAlmostRaidLeader
+		];
+
+		if (allowedRoles.some(x => member.roles.cache.has(x))) {
+			return {
+				isUniversal: true,
+				sectionVerifiedRole: "",
+				highestLeaderRole: "",
+				roleType: null
+			};
+		}
+
+		const returnVal: RaidLeaderStatus = {
+			isUniversal: false,
+			sectionVerifiedRole: section.roles.verifiedRole,
+			highestLeaderRole: "",
+			roleType: null
+		};
+
+		if (member.roles.cache.has(section.roles.raidLeaderRole)) {
+			returnVal.highestLeaderRole = section.roles.raidLeaderRole;
+			returnVal.roleType = "RL";
+		}
+		else if (member.roles.cache.has(section.roles.almostLeaderRole)) {
+			returnVal.highestLeaderRole = section.roles.almostLeaderRole;
+			returnVal.roleType = "ARL";
+		}
+		else if (member.roles.cache.has(section.roles.trialLeaderRole)) {
+			returnVal.highestLeaderRole = section.roles.trialLeaderRole;
+			returnVal.roleType = "TRL";
+		}
+		return returnVal;
+	}
+
+	/**
+	 * Gets the highest RL role type, if any.
+	 * @param {GuildMember} member The member
+	 * @param {IRaidGuild} guildData The guild doc
+	 * @param {ISection} section The section where the command was executed
+	 */
+	export function getHighestRaidLeaderRole(
+		member: GuildMember, 
+		guildData: IRaidGuild, 
+		section: ISection
+	): RaidLeaderRole {
+		if (member.roles.cache.has(guildData.roles.headRaidLeader)) {
+			return "HRL";
+		}
+		else if (member.roles.cache.has(guildData.roles.universalRaidLeader)) {
+			return "RL";
+		}
+		else if (member.roles.cache.has(guildData.roles.universalAlmostRaidLeader)) {
+			return "ARL";
+		}
+
+		// check section
+		if (member.roles.cache.has(section.roles.raidLeaderRole)) {
+			return "RL";
+		}
+		else if (member.roles.cache.has(section.roles.almostLeaderRole)) {
+			return "ARL";
+		}
+		else if (member.roles.cache.has(section.roles.trialLeaderRole)) {
+			return "TRL";
+		}
+
+		return null;
+	}
+
     /**
 	 * Returns the default server section.
 	 * @param {IRaidGuild} guildData The guild data.
@@ -63,4 +157,79 @@ export namespace GuildUtil {
 	export function getSectionRaidLeaderRoles(section: ISection): string[] {
 		return [section.roles.trialLeaderRole, section.roles.almostLeaderRole, section.roles.raidLeaderRole];
 	}
+
+	/* WORKING ON AUTOMATIC ROLE ORDER ORGANIZATION
+	export function getRoleOrder(guild: Guild, db: IRaidGuild): [string, RoleNames][] {
+		const returnVal: [string, RoleNames][] = [];
+		// roles will be sorted
+		// from highest pos to lowest pos
+		const sortedRoles: Role[] = guild.roles.cache
+			.sort((a, b) => b.position - a.position)
+			.array();
+		let i: number = 0;
+
+		for (i = 0; i < sortedRoles.length; i++) {
+			const result: RoleNames | null = resolveRole(db, sortedRoles[i]);
+			if (result === null) {
+				continue;
+			}
+
+
+		}
+		for (const [id, role] of sortedRoles) {
+			const result: RoleNames | null = resolveRole(db, role);
+			if (result === null) {
+				continue;
+			}
+			returnVal.push([id, result]);
+		}
+
+		return returnVal;
+	}
+
+	function resolveRole(guildDb: IRaidGuild, role: Role | string): RoleNames | null {
+		const id: string = typeof role === "string" ? role : role.id;
+		
+		if (guildDb.roles.moderator === id) {
+			return "moderator";
+		}
+		else if (guildDb.roles.officer === id) {
+			return "officer";
+		}
+		else if (guildDb.roles.headRaidLeader === id) {
+			return "headRaidLeader";
+		}
+		else if (guildDb.roles.support === id) {
+			return "support";
+		}
+		else if (guildDb.roles.raider === id) {
+			return "raider";
+		}
+		else if (guildDb.roles.pardonedRaidLeader === id) {
+			return "pardonedRaidLeader";
+		}
+		else if (guildDb.roles.suspended === id) {
+			return "suspended";
+		}
+		else if (guildDb.roles.universalAlmostRaidLeader === id) {
+			return "universalAlmostRaidLeader";
+		}
+		else if (guildDb.roles.universalRaidLeader === id) {
+			return "universalRaidLeader";
+		}
+
+		for (const sec of [getDefaultSection(guildDb), ...guildDb.sections]) {
+			if (sec.roles.almostLeaderRole === id) {
+				return "universalAlmostRaidLeader";
+			}
+			else if (sec.roles.raidLeaderRole === id) {
+				return "universalRaidLeader";
+			}
+			else if (sec.roles.trialLeaderRole === id) {
+				return "trialLeader";
+			}
+		}
+
+		return null;
+	}*/
 }

--- a/src/Utility/GuildUtil.ts
+++ b/src/Utility/GuildUtil.ts
@@ -49,4 +49,18 @@ export namespace GuildUtil {
 			}
 		}
 	}
+
+	/**
+	 * Returns all raid leader roles from a SPECIFIC section.
+	 * 
+	 * INDEX of `getSectionRaidLeaderRoles(ISection);`
+	 * - 0 => TRL
+	 * - 1 => ARL
+	 * - 2 => RL
+	 * 
+	 * @param section The section.
+	 */
+	export function getSectionRaidLeaderRoles(section: ISection): string[] {
+		return [section.roles.trialLeaderRole, section.roles.almostLeaderRole, section.roles.raidLeaderRole];
+	}
 }

--- a/src/Utility/GuildUtil.ts
+++ b/src/Utility/GuildUtil.ts
@@ -107,9 +107,9 @@ export namespace GuildUtil {
 			isMain: true,
 			roles: {
 				verifiedRole: guildData.roles.raider,
-				trialLeaderRole: guildData.roles.sectionTrialLeaderRole,
-				almostLeaderRole: guildData.roles.sectionAlmostLeaderRole,
-				raidLeaderRole: guildData.roles.sectionLeaderRole
+				trialLeaderRole: guildData.roles.mainSectionLeaderRole.sectionTrialLeaderRole,
+				almostLeaderRole: guildData.roles.mainSectionLeaderRole.sectionAlmostLeaderRole,
+				raidLeaderRole: guildData.roles.mainSectionLeaderRole.sectionLeaderRole
 			},
 			channels: {
 				verificationChannel: guildData.generalChannels.verificationChan,

--- a/src/Utility/GuildUtil.ts
+++ b/src/Utility/GuildUtil.ts
@@ -30,7 +30,7 @@ export namespace GuildUtil {
 			guildData.roles.universalAlmostRaidLeader
 		];
 
-		if (allowedRoles.some(x => member.roles.cache.has(x))) {
+		if (allowedRoles.some(x => member.roles.cache.has(x)) || member.hasPermission("ADMINISTRATOR")) {
 			return {
 				isUniversal: true,
 				sectionVerifiedRole: "",

--- a/src/Utility/GuildUtil.ts
+++ b/src/Utility/GuildUtil.ts
@@ -41,7 +41,7 @@ export namespace GuildUtil {
 
 		const returnVal: RaidLeaderStatus = {
 			isUniversal: false,
-			sectionVerifiedRole: section.roles.verifiedRole,
+			sectionVerifiedRole: section.verifiedRole,
 			highestLeaderRole: "",
 			roleType: null
 		};
@@ -105,8 +105,8 @@ export namespace GuildUtil {
 		return {
 			nameOfSection: "Main",
 			isMain: true,
+			verifiedRole: guildData.roles.raider,
 			roles: {
-				verifiedRole: guildData.roles.raider,
 				trialLeaderRole: guildData.roles.mainSectionLeaderRole.sectionTrialLeaderRole,
 				almostLeaderRole: guildData.roles.mainSectionLeaderRole.sectionAlmostLeaderRole,
 				raidLeaderRole: guildData.roles.mainSectionLeaderRole.sectionLeaderRole

--- a/src/Utility/GuildUtil.ts
+++ b/src/Utility/GuildUtil.ts
@@ -11,7 +11,12 @@ export namespace GuildUtil {
 		return {
 			nameOfSection: "Main",
 			isMain: true,
-			verifiedRole: guildData.roles.raider,
+			roles: {
+				verifiedRole: guildData.roles.raider,
+				trialLeaderRole: guildData.roles.sectionTrialLeaderRole,
+				almostLeaderRole: guildData.roles.sectionAlmostLeaderRole,
+				raidLeaderRole: guildData.roles.sectionLeaderRole
+			},
 			channels: {
 				verificationChannel: guildData.generalChannels.verificationChan,
 				afkCheckChannel: guildData.generalChannels.generalRaidAfkCheckChannel,

--- a/src/Utility/MessageUtil.ts
+++ b/src/Utility/MessageUtil.ts
@@ -210,7 +210,7 @@ export namespace MessageUtil {
 			}
 			case ("NO_MENTIONS_FOUND"): {
 				embed.setTitle("No Mentions Found");
-				embed.setDescription("You did not @Mention anyone. Please be sure you mention users.");
+				embed.setDescription("You did not @Mention anyone. Please be sure you mentioned someone.");
 				break;
 			}
 			case ("NO_RESOLVABLE_USER"): {

--- a/src/Zero.ts
+++ b/src/Zero.ts
@@ -48,14 +48,22 @@ export class Zero {
 		Zero.CmdManager.loadAllCommands();
 
 		// events
-		Zero.RaidClient.on("ready", () => onReadyEvent());
-		Zero.RaidClient.on("message", async (msg: Message) => await onMessageEvent(msg));
-		Zero.RaidClient.on("messageReactionAdd", async (reaction: MessageReaction, user: User | PartialUser) => await onMessageReactionAdd(reaction, user));
-		Zero.RaidClient.on("messageReactionRemove", async (reaction: MessageReaction, user: User | PartialUser) => await onMessageReactionRemove(reaction, user));
-		Zero.RaidClient.on("guildMemberAdd", async (member: GuildMember | PartialGuildMember) => await onGuildMemberAdd(member));
-		Zero.RaidClient.on("guildCreate", async (guild: Guild) => await onGuildCreate(guild));
-		Zero.RaidClient.on("guildMemberUpdate", async (oldMember: GuildMember | PartialGuildMember, newMember: GuildMember | PartialGuildMember) => await onGuildMemberUpdate(oldMember, newMember));
-		Zero.RaidClient.on("error", async (error: Error) => onError(error));
+		Zero.RaidClient
+			.on("ready", () => onReadyEvent());
+		Zero.RaidClient
+			.on("message", async (msg: Message) => await onMessageEvent(msg));
+		Zero.RaidClient
+			.on("messageReactionAdd", async (reaction: MessageReaction, user: User | PartialUser) => await onMessageReactionAdd(reaction, user));
+		Zero.RaidClient
+			.on("messageReactionRemove", async (reaction: MessageReaction, user: User | PartialUser) => await onMessageReactionRemove(reaction, user));
+		Zero.RaidClient
+			.on("guildMemberAdd", async (member: GuildMember | PartialGuildMember) => await onGuildMemberAdd(member));
+		Zero.RaidClient
+			.on("guildCreate", async (guild: Guild) => await onGuildCreate(guild));
+		Zero.RaidClient
+			.on("guildMemberUpdate", async (oldMember: GuildMember | PartialGuildMember, newMember: GuildMember | PartialGuildMember) => await onGuildMemberUpdate(oldMember, newMember));
+		Zero.RaidClient
+			.on("error", async (error: Error) => onError(error));
 	}
 
 	/**

--- a/src/Zero.ts
+++ b/src/Zero.ts
@@ -11,6 +11,7 @@ import { onGuildCreate } from "./Events/GuildCreateEvent";
 import { onGuildMemberUpdate } from "./Events/GuildMemberUpdate";
 import { Collection } from "mongodb";
 import { IRaidBot } from "./Templates/IRaidBot";
+import { onError } from "./Events/Error";
 
 export class Zero {
 	/** 
@@ -54,6 +55,7 @@ export class Zero {
 		Zero.RaidClient.on("guildMemberAdd", async (member: GuildMember | PartialGuildMember) => await onGuildMemberAdd(member));
 		Zero.RaidClient.on("guildCreate", async (guild: Guild) => await onGuildCreate(guild));
 		Zero.RaidClient.on("guildMemberUpdate", async (oldMember: GuildMember | PartialGuildMember, newMember: GuildMember | PartialGuildMember) => await onGuildMemberUpdate(oldMember, newMember));
+		Zero.RaidClient.on("error", async (error: Error) => onError(error));
 	}
 
 	/**


### PR DESCRIPTION
Each section can now have its own set of trial, almost, and regular raid leaders! there will also be universal raid leaders & almost leaders.

This also fixes a critical bug where a person's nickname isn't changed if his/her nickname matches his/her Discord username. 

This resolves #5 and #17 . 